### PR TITLE
Sql refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
+      - name: Install Microsoft ODBC
+        run: sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -84,7 +87,6 @@ jobs:
           until bash ./.github/workflows/resources/docker_compose_ready.sh; do
             sleep 2
           done
-
 
       - name: Wait for DB/2
         timeout-minutes: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,15 +78,24 @@ jobs:
           compose-file: ./docker-compose.yaml
 
       - name: Wait for Docker Servers
+        timeout-minutes: 1
         shell: bash
-        run: sleep 2
+        run: |
+          until bash ./.github/workflows/resources/docker_compose_ready.sh; do
+            sleep 2
+          done
+
 
       - name: Wait for DB/2
         timeout-minutes: 2
-        run: until docker logs "${{ job.services.ibm_db2.id }}" 2>&1 | grep -q "Setup has completed"; do sleep 10; echo Waiting; done
+        run: |
+          until docker logs "${{ job.services.ibm_db2.id }}" 2>&1 | grep -q "Setup has completed"; do 
+            sleep 10
+            echo Waiting
+          done
 
       - name: Test
         shell: bash
         run: |
-          poetry run pytest -q tests --ibm_db2
+          poetry run pytest -q tests --mssql --ibm_db2
           # poetry run pytest -s tests  # interactive log output

--- a/.github/workflows/resources/docker_compose_ready.sh
+++ b/.github/workflows/resources/docker_compose_ready.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# This script checks if all the services defined in our docker compose file
+# are up and running.
+
+set -e 
+set -o pipefail
+
+running_services=$(docker compose ps --services --status running)
+
+if [[ "$running_services" =~ "postgres" ]]; then
+	docker compose logs postgres 2>&1 | grep "database system is ready to accept connections" > /dev/null
+fi
+
+if [[ "$running_services" =~ "mssql" ]]; then
+	docker compose logs mssql 2>&1 | grep "SQL Server is now ready for client connections" > /dev/null
+fi
+
+
+if [[ "$running_services" =~ "zoo" ]]; then
+	echo ruok | nc localhost 2181 > /dev/null
+fi
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       # keep port 5432 free since prefect 1 UI also spins up a postgres database on this port
       - 6543:5432
   mssql:
-    image: mcr.microsoft.com/mssql/server:2019-latest
+    image: mcr.microsoft.com/azure-sql-edge
     environment:
       ACCEPT_EULA: Y
       SA_PASSWORD: PidyQuant27
@@ -18,5 +18,7 @@ services:
       - 1433:1433
   zoo:
     image: zookeeper
+    environment:
+      ZOO_4LW_COMMANDS_WHITELIST: ruok
     ports:
       - 2181:2181

--- a/src/pydiverse/pipedag/backend/table/util/__init__.py
+++ b/src/pydiverse/pipedag/backend/table/util/__init__.py
@@ -1,0 +1,1 @@
+from .engine_dispatch import engine_dispatch

--- a/src/pydiverse/pipedag/backend/table/util/engine_dispatch.py
+++ b/src/pydiverse/pipedag/backend/table/util/engine_dispatch.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import functools
+import warnings
+from typing import TYPE_CHECKING, Callable, Protocol
+
+from pydiverse.pipedag._typing import CallableT
+
+if TYPE_CHECKING:
+
+    class EngineDispatchedFn(Protocol):
+        dialect: Callable[[str], Callable[[CallableT], CallableT]]
+        original: CallableT
+
+
+__all__ = [
+    "engine_dispatch",
+]
+
+
+def engine_dispatch(fn: CallableT) -> CallableT | EngineDispatchedFn:
+    """Dispatch a function based on `self.engine.dialect.name`."""
+    fn_variants = {}
+
+    @functools.wraps(fn)
+    def wrapped(*args, **kwargs):
+        self_or_cls = args[0]
+        dialect_name = self_or_cls.engine.dialect.name
+        dispatched_fn = fn_variants.get(dialect_name, fn)
+        return dispatched_fn(*args, **kwargs)
+
+    def dialect_decorator(dialect):
+        def decorate(dialect_fn):
+            if dialect in fn_variants:
+                msg = (
+                    f"Already defined a variant of function '{fn.__name__}'"
+                    f" for dialect '{dialect}'."
+                )
+                warnings.warn(msg)
+            fn_variants[dialect] = dialect_fn
+            return dialect_fn
+
+        return decorate
+
+    wrapped.dialect = dialect_decorator
+    wrapped.original = fn
+    return wrapped

--- a/src/pydiverse/pipedag/backend/table/util/sql_ddl.py
+++ b/src/pydiverse/pipedag/backend/table/util/sql_ddl.py
@@ -362,7 +362,6 @@ def visit_drop_database(drop: DropDatabase, compiler, **kw):
     raise NotImplementedError(
         f"Disable for now for safety reasons (not yet needed): {ret}"
     )
-    # return ret
 
 
 def _visit_create_obj_as_select(create, compiler, _type, kw, *, prefix="", suffix=""):

--- a/src/pydiverse/pipedag/backend/table/util/sql_ddl.py
+++ b/src/pydiverse/pipedag/backend/table/util/sql_ddl.py
@@ -45,10 +45,15 @@ class CreateSchema(DDLElement):
 
 
 class DropSchema(DDLElement):
-    def __init__(self, schema: Schema, if_exists=False, cascade=False):
+    def __init__(self, schema: Schema, if_exists=False, cascade=False, *, engine=None):
+        """
+        :param engine: Used if cascade=True but the database doesn't support cascade.
+        """
         self.schema = schema
         self.if_exists = if_exists
         self.cascade = cascade
+
+        self.engine = engine
 
 
 class RenameSchema(DDLElement):
@@ -202,7 +207,6 @@ def visit_create_schema(create: CreateSchema, compiler, **kw):
         return create_database
 
 
-# noinspection SqlDialectInspection
 @compiles(CreateSchema, "ibm_db_sa")
 def visit_create_schema(create: CreateSchema, compiler, **kw):
     """For IBM DB2 we need to jump through extra hoops for if_exists=True."""
@@ -252,19 +256,52 @@ def visit_drop_schema(drop: DropSchema, compiler, **kw):
     return " ".join(text)
 
 
-# noinspection SqlDialectInspection
 @compiles(DropSchema, "ibm_db_sa")
 def visit_drop_schema(drop: DropSchema, compiler, **kw):
-    """For IBM DB2 we need to jump through extra hoops for if_exists=True."""
-    _ = kw
+    """
+    Because IBM DB2 doesn't support CASCADE, we must manually drop all tables in
+    the schema first.
+    """
+    statements = []
+    if drop.cascade:
+        if drop.engine is None:
+            raise ValueError(
+                "Using DropSchema with cascade=True for ibm_db2 requires passing"
+                " the engine kwarg to DropSchema."
+            )
+
+        with drop.engine.connect() as conn:
+            meta = sa.MetaData()
+            meta.reflect(bind=conn, schema=drop.schema.get())
+
+        kw["literal_binds"] = True
+        for table in meta.tables.values():
+            drop_table = compiler.process(DropTable(table.name, drop.schema), **kw)
+            statements.append(drop_table)
+
+    # Compile DROP SCHEMA statement
+    schema = compiler.preparer.format_schema(drop.schema.get())
+    text = ["DROP SCHEMA"]
+    if drop.if_exists:
+        text.append("IF EXISTS")
+    text.append(schema)
+    statements.append(" ".join(text))
+
+    return ";\n".join(statements)
+
+
+@compiles(DropSchema, "ibm_db_sa")
+def visit_drop_schema(drop: DropSchema, compiler, **_):
     schema = compiler.preparer.format_schema(drop.schema.get())
     if drop.if_exists:
-        return (
-            "BEGIN\ndeclare continue handler for sqlstate '42704' begin end;\n"
-            f"execute immediate 'DROP SCHEMA {schema} RESTRICT';\nEND"
-        )
-    else:
-        return f"DROP SCHEMA {schema} RESTRICT"
+        # Add error handler to cache the case that the schema doesn't exist
+        return f"""
+            BEGIN
+                declare continue handler for sqlstate '42704' begin end;
+                execute immediate 'DROP SCHEMA {schema} RESTRICT';
+            END
+            """.strip()
+    return f"DROP SCHEMA {schema} RESTRICT"
 
 
 @compiles(RenameSchema)
@@ -331,7 +368,6 @@ def visit_drop_database(drop: DropDatabase, compiler, **kw):
 def _visit_create_obj_as_select(create, compiler, _type, kw, *, prefix="", suffix=""):
     name = compiler.preparer.quote_identifier(create.name)
     schema = compiler.preparer.format_schema(create.schema.get())
-    kw = kw.copy()
     kw["literal_binds"] = True
     select = compiler.sql_compiler.process(create.query, **kw)
     return f"CREATE {_type} {schema}.{name} AS\n{prefix}{select}{suffix}"
@@ -351,7 +387,6 @@ def visit_create_table_as_select(create: CreateTableAsSelect, compiler, **kw):
     database = compiler.preparer.format_schema(database_name)
     schema = compiler.preparer.format_schema(schema_name)
 
-    kw = kw.copy()
     kw["literal_binds"] = True
     select = compiler.sql_compiler.process(create.query, **kw)
 
@@ -365,7 +400,6 @@ def visit_create_table_as_select(create: CreateTableAsSelect, compiler, **kw):
 
     name = compiler.preparer.quote_identifier(create_name)
     schema = compiler.preparer.format_schema(create.schema.get())
-    kw = kw.copy()
     kw["literal_binds"] = True
     select = compiler.sql_compiler.process(create.query, **kw)
     return f"INSERT INTO {schema}.{name}\n{select}"
@@ -428,17 +462,15 @@ def insert_into_in_query(select_sql, database, schema, table):
     )
 
 
-# noinspection SqlDialectInspection
 @compiles(CopyTable)
 def visit_copy_table(copy_table: CopyTable, compiler, **kw):
     from_name = compiler.preparer.quote_identifier(copy_table.from_name)
     from_schema = compiler.preparer.format_schema(copy_table.from_schema.get())
-    query = sa.text(f"SELECT * FROM {from_schema}.{from_name}")
+    query = sa.select("*").select_from(sa.text(f"{from_schema}.{from_name}"))
     create = CreateTableAsSelect(copy_table.to_name, copy_table.to_schema, query)
     return compiler.process(create, **kw)
 
 
-# noinspection SqlDialectInspection
 @compiles(CopyTable, "mssql")
 def visit_copy_table(copy_table: CopyTable, compiler, **kw):
     from_name = compiler.preparer.quote_identifier(copy_table.from_name)
@@ -551,4 +583,4 @@ def _visit_drop_anything_mssql(
 
 def ibm_db_sa_fix_name(name):
     # DB2 seems to create tables uppercase if all lowercase given
-    return name.upper() if all(c.lower() == c for c in name) else name
+    return name.upper() if name.islower() else name

--- a/src/pydiverse/pipedag/core/stage.py
+++ b/src/pydiverse/pipedag/core/stage.py
@@ -75,6 +75,11 @@ class Stage:
     def transaction_name(self) -> str:
         return self._transaction_name
 
+    def set_transaction_name(self, new_transaction_name):
+        # used by stage_commit_technique=READ_VIEWS to change odd/even
+        # transaction schemas
+        self._transaction_name = new_transaction_name
+
     @property
     def current_name(self) -> str:
         """The name of the stage where the data currently lives
@@ -151,11 +156,6 @@ class Stage:
         state.pop("outer_stage", None)
         state.pop("logger", None)
         return state
-
-    def set_transaction_name(self, new_transaction_name):
-        # used by stage_commit_technique=READ_VIEWS to change odd/even
-        # transaction schemas
-        self._transaction_name = new_transaction_name
 
 
 class CommitStageTask(Task):

--- a/tests/test_sql_ddl.py
+++ b/tests/test_sql_ddl.py
@@ -1,7 +1,6 @@
 from pydiverse.pipedag.backend.table.util.sql_ddl import insert_into_in_query
 
 
-# noinspection SqlDialectInspection
 def test_insert_into():
     test_pairs = {
         "Select 1": "Select 1 INTO a.b.c",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,6 +2,7 @@ import pytest
 
 from pydiverse.pipedag.errors import DisposedError
 from pydiverse.pipedag.util import Disposable, requires
+from pydiverse.pipedag.backend.table.util import engine_dispatch
 
 
 def test_requires():
@@ -49,3 +50,51 @@ def test_disposable():
         x.dispose()
     with pytest.raises(DisposedError):
         x.a = 1
+
+
+def test_sql_engine_dispatch():
+    class Dialect:
+        def __init__(self, name):
+            self.name = name
+
+    class Engine:
+        def __init__(self, dialect):
+            self.dialect = Dialect(dialect)
+
+    class X:
+        def __init__(self, dialect):
+            self.engine = Engine(dialect)
+
+        @engine_dispatch
+        def foo(self):
+            return "base"
+
+        @foo.dialect("dialect1")
+        def _foo_var1(self):
+            return "dialect1"
+
+        @foo.dialect("dialect2")
+        def _foo_var2(self):
+            return "dialect2"
+
+        @engine_dispatch
+        def bar(self, a, b):
+            return a
+
+        @bar.dialect("dialect1")
+        def _bar_var1(self, a, b):
+            return b
+
+        @bar.dialect("dialect2")
+        def _bar_var2(self, a, b):
+            return self.bar.original(self, a, b)
+
+    assert X("xyz").foo() == "base"
+    assert X("qwerty").foo() == "base"
+    assert X("dialect1").foo() == "dialect1"
+    assert X("dialect2").foo() == "dialect2"
+
+    assert X("xyz").bar(1, 2) == 1
+    assert X("qwerty").bar(1, 2) == 1
+    assert X("dialect1").bar(1, 2) == 2
+    assert X("dialect2").bar(1, 2) == 1


### PR DESCRIPTION
This PR cleans up how we handle different sql dialects. It introduces a `engine_dispatch` decorator that dispatches to the correct function implementation based on the current engine's dialect. This allows for significantly less nested and more readable code.

I also changed how `DropSchema` with `cascade=True` gets handled for IBM Db2. Instead of manually having to drop everything in the schema before calling `DropSchema`, the `DropSchema` visitor now inspects the schema and creates an sql query that first drops all tables and only then drops the schema.

Finally, I also replaced the `mcr.microsoft.com/mssql/server:2019-latest` docker image with `mcr.microsoft.com/azure-sql-edge`, because the latter also works on Apple Silicon Macs.