### PR TITLE
Create Primary Keys and Indexes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Changelog
 ------------------
 
 - SQLTableStore: support for Microsoft SQL Server and IBM DB2 (Linux) database connection strings
+- Support primary keys and indexes (can be configured with Table object and used in custom RawSql code)
 - RawSql: support additional return type for @materialize tasks which allows to emit raw SQL string including multiple
    create statements (currently, views/functions/procedures are only supported for dialect mssql). This feature should
    only be used for getting legacy code running in pipedag before converting it to programatically generated or manual

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,13 +1,13 @@
 .. Versioning follows semantic versioning, see also
 https://semver.org/spec/v2.0.0.html. The most important bits are:
-* Update the major if you break the public API
+* Update the major if you break the public API and major > 0
 * Update the minor if you add new functionality
 * Update the patch if you fixed a bug
 
 Changelog
 =========
 
-0.2.0 (2022-MM-DD)
+0.2.0 (2022-01-14)
 ------------------
 
 - SQLTableStore: support for Microsoft SQL Server and IBM DB2 (Linux) database connection strings

--- a/src/pydiverse/pipedag/backend/table/base.py
+++ b/src/pydiverse/pipedag/backend/table/base.py
@@ -223,7 +223,7 @@ class BaseTableStore(Disposable, metaclass=_TableStoreMeta):
             metadata = self.retrieve_lazy_table_metadata(
                 query_hash, task_hash, table.stage
             )
-            self.copy_lazy_table_to_transaction(metadata, table.stage)
+            self.copy_lazy_table_to_transaction(metadata, table)
             self.logger.info(f"Lazy cache of table '{table.name}' found")
             table.name = metadata.name
         except CacheError as e:
@@ -306,8 +306,9 @@ class BaseTableStore(Disposable, metaclass=_TableStoreMeta):
         """
 
     @abstractmethod
-    def copy_lazy_table_to_transaction(self, metadata: LazyTableMetadata, stage: Stage):
-        """Copy the lazy table identified by the metadata to the transaction stage.
+    def copy_lazy_table_to_transaction(self, metadata: LazyTableMetadata, table: Table):
+        """Copy the lazy table identified by the metadata to the transaction stage of
+        table.
 
         This operation MUST not remove the table from the base stage or modify
         it in any way.

--- a/src/pydiverse/pipedag/backend/table/dict.py
+++ b/src/pydiverse/pipedag/backend/table/dict.py
@@ -59,7 +59,8 @@ class DictTableStore(BaseTableStore):
                 f"No table with name '{table.name}' found in '{stage.name}' stage"
             ) from None
 
-    def copy_lazy_table_to_transaction(self, metadata: LazyTableMetadata, stage: Stage):
+    def copy_lazy_table_to_transaction(self, metadata: LazyTableMetadata, table: Table):
+        stage = table.stage
         if stage.did_commit:
             raise StageError(
                 f"Can't copy table '{metadata.name}' to transaction."

--- a/src/pydiverse/pipedag/backend/table/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql.py
@@ -1007,7 +1007,9 @@ class SQLTableStore(BaseTableStore):
 class SQLAlchemyTableHook(TableHook[SQLTableStore]):
     @classmethod
     def can_materialize(cls, type_) -> bool:
-        return issubclass(type_, (sa.Table, sa.sql.Select, sa.sql.elements.TextClause))
+        return issubclass(
+            type_, (sa.sql.elements.TextClause, sa.sql.selectable.Selectable)
+        )
 
     @classmethod
     def can_retrieve(cls, type_) -> bool:

--- a/src/pydiverse/pipedag/backend/table/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql.py
@@ -658,7 +658,8 @@ class SQLTableStore(BaseTableStore):
             raise CacheError(msg) from _e
         self.add_indexes(table, self.get_schema(stage.transaction_name))
 
-    def copy_lazy_table_to_transaction(self, metadata: LazyTableMetadata, stage: Stage):
+    def copy_lazy_table_to_transaction(self, metadata: LazyTableMetadata, table: Table):
+        stage = table.stage
         schema_name = self.get_schema(metadata.stage).get()
         has_table = sa.inspect(self.engine).has_table(metadata.name, schema=schema_name)
         if not has_table:
@@ -683,7 +684,7 @@ class SQLTableStore(BaseTableStore):
                 f" '{metadata.stage}') to transaction."
             )
             raise CacheError(msg) from _e
-        # self.add_indexes(table, self.get_schema(stage.transaction_name))
+        self.add_indexes(table, self.get_schema(stage.transaction_name))
 
     @engine_dispatch
     def get_view_names(self, schema: str, *, include_everything=False) -> list[str]:

--- a/src/pydiverse/pipedag/backend/table/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql.py
@@ -656,6 +656,7 @@ class SQLTableStore(BaseTableStore):
                 " to transaction."
             )
             raise CacheError(msg) from _e
+        self.add_indexes(table, self.get_schema(stage.transaction_name))
 
     def copy_lazy_table_to_transaction(self, metadata: LazyTableMetadata, stage: Stage):
         schema_name = self.get_schema(metadata.stage).get()
@@ -682,6 +683,7 @@ class SQLTableStore(BaseTableStore):
                 f" '{metadata.stage}') to transaction."
             )
             raise CacheError(msg) from _e
+        # self.add_indexes(table, self.get_schema(stage.transaction_name))
 
     @engine_dispatch
     def get_view_names(self, schema: str, *, include_everything=False) -> list[str]:

--- a/src/pydiverse/pipedag/backend/table/util/sql_ddl.py
+++ b/src/pydiverse/pipedag/backend/table/util/sql_ddl.py
@@ -25,6 +25,8 @@ __all__ = [
     "DropView",
     "AddPrimaryKey",
     "AddIndex",
+    "ChangeColumnNullable",
+    "ChangeColumnTypes",
     "split_ddl_statement",
 ]
 

--- a/src/pydiverse/pipedag/backend/table/util/sql_ddl.py
+++ b/src/pydiverse/pipedag/backend/table/util/sql_ddl.py
@@ -152,17 +152,31 @@ class DropFunction(DDLElement):
 
 
 class AddPrimaryKey(DDLElement):
-    def __init__(self, table_name: str, schema: Schema, key: list[str]):
+    def __init__(
+        self,
+        table_name: str,
+        schema: Schema,
+        key_columns: list[str],
+        name: str | None = None,
+    ):
         self.table_name = table_name
         self.schema = schema
-        self.key = key
+        self.key = key_columns
+        self.name = name
 
 
 class AddIndex(DDLElement):
-    def __init__(self, table_name: str, schema: Schema, index: list[str]):
+    def __init__(
+        self,
+        table_name: str,
+        schema: Schema,
+        index_columns: list[str],
+        name: str | None = None,
+    ):
         self.table_name = table_name
         self.schema = schema
-        self.index = index
+        self.index = index_columns
+        self.name = name
 
 
 class ChangeColumnTypes(DDLElement):
@@ -621,7 +635,11 @@ def visit_add_primary_key(add_primary_key: AddPrimaryKey, compiler, **kw):
     _ = kw
     table = compiler.preparer.quote_identifier(add_primary_key.table_name)
     schema = compiler.preparer.format_schema(add_primary_key.schema.get())
-    pk_name = compiler.preparer.quote_identifier("pk_" + "_".join(add_primary_key.key))
+    pk_name = compiler.preparer.quote_identifier(
+        add_primary_key.name
+        if add_primary_key.name is not None
+        else "pk_" + "_".join(add_primary_key.key)
+    )
     cols = ",".join(
         [compiler.preparer.quote_identifier(col) for col in add_primary_key.key]
     )
@@ -635,7 +653,11 @@ def visit_add_primary_key(add_primary_key: AddPrimaryKey, compiler, **kw):
     database, schema = _get_mssql_database_schema(add_primary_key.schema, compiler)
 
     table = compiler.preparer.quote_identifier(add_primary_key.table_name)
-    pk_name = compiler.preparer.quote_identifier("pk_" + "_".join(add_primary_key.key))
+    pk_name = compiler.preparer.quote_identifier(
+        add_primary_key.name
+        if add_primary_key.name is not None
+        else "pk_" + "_".join(add_primary_key.key)
+    )
     cols = ",".join(
         [compiler.preparer.quote_identifier(col) for col in add_primary_key.key]
     )
@@ -655,7 +677,11 @@ def visit_add_primary_key(add_primary_key: AddPrimaryKey, compiler, **kw):
 
     table = compiler.preparer.quote_identifier(add_primary_key.table_name)
     schema = compiler.preparer.format_schema(add_primary_key.schema.get())
-    pk_name = compiler.preparer.quote_identifier("pk_" + "_".join(add_primary_key.key))
+    pk_name = compiler.preparer.quote_identifier(
+        add_primary_key.name
+        if add_primary_key.name is not None
+        else "pk_" + "_".join(add_primary_key.key)
+    )
     cols = ",".join(
         [
             compiler.preparer.quote_identifier(ibm_db_sa_fix_name(col))
@@ -671,7 +697,11 @@ def visit_add_index(add_index: AddIndex, compiler, **kw):
     _ = kw
     table = compiler.preparer.quote_identifier(add_index.table_name)
     schema = compiler.preparer.format_schema(add_index.schema.get())
-    index_name = compiler.preparer.quote_identifier("idx_" + "_".join(add_index.index))
+    index_name = compiler.preparer.quote_identifier(
+        add_index.name
+        if add_index.name is not None
+        else "idx_" + "_".join(add_index.index)
+    )
     cols = ",".join(
         [compiler.preparer.quote_identifier(col) for col in add_index.index]
     )
@@ -685,7 +715,11 @@ def visit_add_index(add_index: AddIndex, compiler, **kw):
     database, schema = _get_mssql_database_schema(add_index.schema, compiler)
 
     table = compiler.preparer.quote_identifier(add_index.table_name)
-    index_name = compiler.preparer.quote_identifier("idx_" + "_".join(add_index.index))
+    index_name = compiler.preparer.quote_identifier(
+        add_index.name
+        if add_index.name is not None
+        else "idx_" + "_".join(add_index.index)
+    )
     cols = ",".join(
         [compiler.preparer.quote_identifier(col) for col in add_index.index]
     )
@@ -702,7 +736,11 @@ def visit_add_index(add_index: AddIndex, compiler, **kw):
 
     table = compiler.preparer.quote_identifier(add_index.table_name)
     schema = compiler.preparer.format_schema(add_index.schema.get())
-    index_name = compiler.preparer.quote_identifier("idx_" + "_".join(add_index.index))
+    index_name = compiler.preparer.quote_identifier(
+        add_index.name
+        if add_index.name is not None
+        else "idx_" + "_".join(add_index.index)
+    )
     cols = ",".join(
         [
             compiler.preparer.quote_identifier(ibm_db_sa_fix_name(col))

--- a/src/pydiverse/pipedag/backend/table/util/sql_ddl.py
+++ b/src/pydiverse/pipedag/backend/table/util/sql_ddl.py
@@ -23,6 +23,8 @@ __all__ = [
     "DropFunction",
     "DropProcedure",
     "DropView",
+    "AddPrimaryKey",
+    "AddIndex",
     "split_ddl_statement",
 ]
 
@@ -147,6 +149,56 @@ class DropFunction(DDLElement):
         self.if_exists = if_exists
 
 
+class AddPrimaryKey(DDLElement):
+    def __init__(self, table_name: str, schema: Schema, key: list[str]):
+        self.table_name = table_name
+        self.schema = schema
+        self.key = key
+
+
+class AddIndex(DDLElement):
+    def __init__(self, table_name: str, schema: Schema, index: list[str]):
+        self.table_name = table_name
+        self.schema = schema
+        self.index = index
+
+
+class ChangeColumnTypes(DDLElement):
+    def __init__(
+        self,
+        table_name: str,
+        schema: Schema,
+        column_names: list[str],
+        column_types: list[str],
+        nullable: bool | list[bool] | None = None,
+        cap_varchar_max: int | None = None,
+    ):
+        if not isinstance(nullable, list):
+            nullable = [nullable for _ in column_names]
+        self.table_name = table_name
+        self.schema = schema
+        self.column_names = column_names
+        self.column_types = column_types
+        self.nullable = nullable
+        self.cap_varchar_max = cap_varchar_max
+
+
+class ChangeColumnNullable(DDLElement):
+    def __init__(
+        self,
+        table_name: str,
+        schema: Schema,
+        column_names: list[str],
+        nullable: bool | list[bool],
+    ):
+        if isinstance(nullable, bool):
+            nullable = [nullable for _ in column_names]
+        self.table_name = table_name
+        self.schema = schema
+        self.column_names = column_names
+        self.nullable = nullable
+
+
 @compiles(CreateSchema)
 def visit_create_schema(create: CreateSchema, compiler, **kw):
     _ = kw
@@ -158,6 +210,7 @@ def visit_create_schema(create: CreateSchema, compiler, **kw):
     return " ".join(text)
 
 
+# noinspection SqlDialectInspection
 @compiles(CreateSchema, "mssql")
 def visit_create_schema_mssql(create: CreateSchema, compiler, **kw):
     # For SQL Server we support two modes:  using databases as schemas,
@@ -246,6 +299,7 @@ def visit_drop_schema_mssql(drop: DropSchema, compiler, **kw):
     return " ".join(text)
 
 
+# noinspection SqlDialectInspection
 @compiles(DropSchema, "ibm_db_sa")
 def visit_drop_schema_ibm_db_sa(drop: DropSchema, compiler, **kw):
     """
@@ -373,6 +427,7 @@ def visit_create_table_as_select_mssql(create: CreateTableAsSelect, compiler, **
     return insert_into_in_query(select, database, schema, name)
 
 
+# noinspection SqlDialectInspection
 @compiles(CreateTableAsSelect, "ibm_db_sa")
 def visit_create_table_as_select_ibm_db_sa(create: CreateTableAsSelect, compiler, **kw):
     # DB2 stores capitalized table names but sqlalchemy reflects them lowercase
@@ -447,14 +502,11 @@ def visit_copy_table(copy_table: CopyTable, compiler, **kw):
     return compiler.process(create, **kw)
 
 
+# noinspection SqlDialectInspection
 @compiles(CopyTable, "mssql")
 def visit_copy_table_mssql(copy_table: CopyTable, compiler, **kw):
     from_name = compiler.preparer.quote_identifier(copy_table.from_name)
-    full_name = copy_table.from_schema.get()
-    # it was already checked that there is exactly one dot in schema prefix + suffix
-    database_name, schema_name = full_name.split(".")
-    database = compiler.preparer.format_schema(database_name)
-    schema = compiler.preparer.format_schema(schema_name)
+    database, schema = _get_mssql_database_schema(copy_table.from_schema, compiler)
     query = sa.text(f"SELECT * FROM {database}.{schema}.{from_name}")
     create = CreateTableAsSelect(copy_table.to_name, copy_table.to_schema, query)
     return compiler.process(create, **kw)
@@ -549,11 +601,7 @@ def _visit_drop_anything_mssql(
 ):
     _ = kw
     table = compiler.preparer.quote_identifier(drop.name)
-    full_name = drop.schema.get()
-    # it was already checked that there is exactly one dot in schema prefix + suffix
-    database_name, schema_name = full_name.split(".")
-    database = compiler.preparer.format_schema(database_name)
-    schema = compiler.preparer.format_schema(schema_name)
+    database, schema = _get_mssql_database_schema(drop.schema, compiler)
     text = [f"DROP {_type}"]
     if drop.if_exists:
         text.append("IF EXISTS")
@@ -563,6 +611,232 @@ def _visit_drop_anything_mssql(
     else:
         text.append(f"{database}.{schema}.{table}")
     return " ".join(text)
+
+
+# noinspection SqlDialectInspection
+@compiles(AddPrimaryKey)
+def visit_add_primary_key(add_primary_key: AddPrimaryKey, compiler, **kw):
+    _ = kw
+    table = compiler.preparer.quote_identifier(add_primary_key.table_name)
+    schema = compiler.preparer.format_schema(add_primary_key.schema.get())
+    pk_name = compiler.preparer.quote_identifier("pk_" + "_".join(add_primary_key.key))
+    cols = ",".join(
+        [compiler.preparer.quote_identifier(col) for col in add_primary_key.key]
+    )
+    return f"ALTER TABLE {schema}.{table} ADD CONSTRAINT {pk_name} PRIMARY KEY ({cols})"
+
+
+# noinspection SqlDialectInspection
+@compiles(AddPrimaryKey, "mssql")
+def visit_add_primary_key(add_primary_key: AddPrimaryKey, compiler, **kw):
+    _ = kw
+    database, schema = _get_mssql_database_schema(add_primary_key.schema, compiler)
+
+    table = compiler.preparer.quote_identifier(add_primary_key.table_name)
+    pk_name = compiler.preparer.quote_identifier("pk_" + "_".join(add_primary_key.key))
+    cols = ",".join(
+        [compiler.preparer.quote_identifier(col) for col in add_primary_key.key]
+    )
+    return (
+        f"ALTER TABLE {database}.{schema}.{table} ADD CONSTRAINT {pk_name} PRIMARY KEY"
+        f" ({cols})"
+    )
+
+
+# noinspection SqlDialectInspection
+@compiles(AddPrimaryKey, "ibm_db_sa")
+def visit_add_primary_key(add_primary_key: AddPrimaryKey, compiler, **kw):
+    _ = kw
+    # DB2 stores capitalized table names but sqlalchemy reflects them lowercase
+    add_primary_key = copy.deepcopy(add_primary_key)
+    add_primary_key.table_name = ibm_db_sa_fix_name(add_primary_key.table_name)
+
+    table = compiler.preparer.quote_identifier(add_primary_key.table_name)
+    schema = compiler.preparer.format_schema(add_primary_key.schema.get())
+    pk_name = compiler.preparer.quote_identifier("pk_" + "_".join(add_primary_key.key))
+    cols = ",".join(
+        [
+            compiler.preparer.quote_identifier(ibm_db_sa_fix_name(col))
+            for col in add_primary_key.key
+        ]
+    )
+    return f"ALTER TABLE {schema}.{table} ADD CONSTRAINT {pk_name} PRIMARY KEY ({cols})"
+
+
+# noinspection SqlDialectInspection
+@compiles(AddIndex)
+def visit_add_index(add_index: AddIndex, compiler, **kw):
+    _ = kw
+    table = compiler.preparer.quote_identifier(add_index.table_name)
+    schema = compiler.preparer.format_schema(add_index.schema.get())
+    index_name = compiler.preparer.quote_identifier("idx_" + "_".join(add_index.index))
+    cols = ",".join(
+        [compiler.preparer.quote_identifier(col) for col in add_index.index]
+    )
+    return f"CREATE INDEX {index_name} ON {schema}.{table} ({cols})"
+
+
+# noinspection SqlDialectInspection
+@compiles(AddIndex, "mssql")
+def visit_add_index(add_index: AddIndex, compiler, **kw):
+    _ = kw
+    database, schema = _get_mssql_database_schema(add_index.schema, compiler)
+
+    table = compiler.preparer.quote_identifier(add_index.table_name)
+    index_name = compiler.preparer.quote_identifier("idx_" + "_".join(add_index.index))
+    cols = ",".join(
+        [compiler.preparer.quote_identifier(col) for col in add_index.index]
+    )
+    return f"CREATE INDEX {index_name} ON {database}.{schema}.{table} ({cols})"
+
+
+# noinspection SqlDialectInspection
+@compiles(AddIndex, "ibm_db_sa")
+def visit_add_index(add_index: AddIndex, compiler, **kw):
+    _ = kw
+    # DB2 stores capitalized table names but sqlalchemy reflects them lowercase
+    add_index = copy.deepcopy(add_index)
+    add_index.table_name = ibm_db_sa_fix_name(add_index.table_name)
+
+    table = compiler.preparer.quote_identifier(add_index.table_name)
+    schema = compiler.preparer.format_schema(add_index.schema.get())
+    index_name = compiler.preparer.quote_identifier("idx_" + "_".join(add_index.index))
+    cols = ",".join(
+        [
+            compiler.preparer.quote_identifier(ibm_db_sa_fix_name(col))
+            for col in add_index.index
+        ]
+    )
+    return f"CREATE INDEX {schema}.{index_name} ON {schema}.{table} ({cols})"
+
+
+@compiles(ChangeColumnTypes)
+def visit_change_column_types(change: ChangeColumnTypes, compiler, **kw):
+    _ = kw
+    table = compiler.preparer.quote_identifier(change.table_name)
+    schema = compiler.preparer.format_schema(change.schema.get())
+    alter_columns = ",".join(
+        [
+            f"ALTER COLUMN {compiler.preparer.quote_identifier(col)} SET DATA TYPE"
+            f" {compiler.type_compiler.process(_type)}"
+            for col, _type, nullable in zip(
+                change.column_names, change.column_types, change.nullable
+            )
+        ]
+        + [
+            "ALTER COLUMN"
+            f" {compiler.preparer.quote_identifier(col)}"
+            f" {'SET' if not nullable else 'DROP'} NOT NULL"
+            for col, nullable in zip(change.column_names, change.nullable)
+            if nullable is not None
+        ]
+    )
+    return f"ALTER TABLE {schema}.{table} {alter_columns}"
+
+
+# noinspection SqlDialectInspection
+@compiles(ChangeColumnTypes, "mssql")
+def visit_change_column_types(change: ChangeColumnTypes, compiler, **kw):
+    _ = kw
+    database, schema = _get_mssql_database_schema(change.schema, compiler)
+
+    table = compiler.preparer.quote_identifier(change.table_name)
+
+    def modify_type(_type):
+        if change.cap_varchar_max is not None:
+            _type = copy.copy(_type)
+            if isinstance(_type, sa.String) and (
+                _type.length is None or _type.length > change.cap_varchar_max
+            ):
+                # impose some limit to allow use in primary key / index
+                _type.length = change.cap_varchar_max
+        return _type
+
+    statements = [
+        f"ALTER TABLE {database}.{schema}.{table} ALTER COLUMN"
+        f" {compiler.preparer.quote_identifier(col)} "
+        f"{compiler.type_compiler.process(modify_type(_type))}"
+        f"{'' if nullable is None else ' NULL' if nullable else ' NOT NULL'}"
+        for col, _type, nullable in zip(
+            change.column_names, change.column_types, change.nullable
+        )
+    ]
+    return join_ddl_statements(statements, compiler, **kw)
+
+
+# noinspection SqlDialectInspection
+@compiles(ChangeColumnTypes, "ibm_db_sa")
+def visit_change_column_types(change: ChangeColumnTypes, compiler, **kw):
+    _ = kw
+    # DB2 stores capitalized table names but sqlalchemy reflects them lowercase
+    change = copy.deepcopy(change)
+    change.table_name = ibm_db_sa_fix_name(change.table_name)
+
+    def modify_type(_type):
+        if change.cap_varchar_max is not None:
+            _type = copy.copy(_type)
+            if isinstance(_type, sa.String) and (
+                _type.length is None or _type.length > change.cap_varchar_max
+            ):
+                # impose some limit to allow use in primary key / index
+                _type.length = change.cap_varchar_max
+        return _type
+
+    table = compiler.preparer.quote_identifier(change.table_name)
+    schema = compiler.preparer.format_schema(change.schema.get())
+    statements = [
+        f"ALTER TABLE {schema}.{table} ALTER COLUMN"
+        f" {compiler.preparer.quote_identifier(ibm_db_sa_fix_name(col))} SET DATA TYPE"
+        f" {compiler.type_compiler.process(modify_type(_type))}"
+        for col, _type, nullable in zip(
+            change.column_names, change.column_types, change.nullable
+        )
+    ] + [
+        f"ALTER TABLE {schema}.{table} ALTER COLUMN"
+        f" {compiler.preparer.quote_identifier(ibm_db_sa_fix_name(col))}"
+        f" {'SET' if not nullable else 'DROP'} NOT NULL"
+        for col, nullable in zip(change.column_names, change.nullable)
+        if nullable is not None
+    ]
+    statements.append(f"call sysproc.admin_cmd('REORG TABLE {schema}.{table}')")
+    return join_ddl_statements(statements, compiler, **kw)
+
+
+# noinspection SqlDialectInspection
+@compiles(ChangeColumnNullable)
+def visit_change_column_types(change: ChangeColumnNullable, compiler, **kw):
+    _ = kw
+    table = compiler.preparer.quote_identifier(change.table_name)
+    schema = compiler.preparer.format_schema(change.schema.get())
+    alter_columns = ",".join(
+        [
+            "ALTER COLUMN"
+            f" {compiler.preparer.quote_identifier(col)}"
+            f" {'SET' if not nullable else 'DROP'} NOT NULL"
+            for col, nullable in zip(change.column_names, change.nullable)
+        ]
+    )
+    return f"ALTER TABLE {schema}.{table} {alter_columns}"
+
+
+# noinspection SqlDialectInspection
+@compiles(ChangeColumnNullable, "ibm_db_sa")
+def visit_change_column_types(change: ChangeColumnNullable, compiler, **kw):
+    _ = kw
+    # DB2 stores capitalized table names but sqlalchemy reflects them lowercase
+    change = copy.deepcopy(change)
+    change.table_name = ibm_db_sa_fix_name(change.table_name)
+
+    table = compiler.preparer.quote_identifier(change.table_name)
+    schema = compiler.preparer.format_schema(change.schema.get())
+    statements = [
+        f"ALTER TABLE {schema}.{table} ALTER COLUMN"
+        f" {compiler.preparer.quote_identifier(ibm_db_sa_fix_name(col))}"
+        f" {'SET' if not nullable else 'DROP'} NOT NULL"
+        for col, nullable in zip(change.column_names, change.nullable)
+    ]
+    statements.append(f"call sysproc.admin_cmd('REORG TABLE {schema}.{table}')")
+    return join_ddl_statements(statements, compiler, **kw)
 
 
 def ibm_db_sa_fix_name(name):
@@ -588,3 +862,12 @@ def join_ddl_statements(statements, compiler, **kw):
 def split_ddl_statement(statement: str):
     """Split previously combined DDL statements apart"""
     return statement.split(STATEMENT_SEPERATOR)
+
+
+def _get_mssql_database_schema(schema: Schema, compiler):
+    full_name = schema.get()
+    # it was already checked that there is exactly one dot in schema prefix + suffix
+    database_name, schema_name = full_name.split(".")
+    database = compiler.preparer.format_schema(database_name)
+    schema = compiler.preparer.format_schema(schema_name)
+    return database, schema

--- a/src/pydiverse/pipedag/materialize/container.py
+++ b/src/pydiverse/pipedag/materialize/container.py
@@ -31,7 +31,8 @@ class Table(Generic[T]):
         obj: T | None = None,
         name: str | None = None,
         stage: Stage | None = None,
-        primary_key: str | None = None,
+        primary_key: str | list[str] | None = None,
+        indexes: list[list[str]] | None = None,
         *,
         cache_key: str | None = None,
     ):
@@ -41,6 +42,7 @@ class Table(Generic[T]):
         self.name = name
         self.stage = stage
         self.primary_key = primary_key
+        self.indexes = indexes
 
         self.cache_info = CacheInfo(cache_key)
 

--- a/src/pydiverse/pipedag/materialize/util/json.py
+++ b/src/pydiverse/pipedag/materialize/util/json.py
@@ -30,6 +30,8 @@ def json_default(o):
             PIPEDAG_TYPE: PIPEDAG_TYPE_TABLE,
             "stage": o.stage.name,
             "name": o.name,
+            "primary_key": o.primary_key,
+            "indexes": o.indexes,
             "cache_key": o.cache_info.cache_key,
         }
     if isinstance(o, RawSql):
@@ -76,6 +78,8 @@ def json_object_hook(d: dict):
             return Table(
                 name=d["name"],
                 stage=stages[d["stage"]],
+                primary_key=d["primary_key"],
+                indexes=d["indexes"],
                 cache_key=d["cache_key"],
             )
         elif pipedag_type == PIPEDAG_TYPE_RAWSQL:

--- a/tests/test_flows/raw_sql_scripts/mssql/prep/more_tables.sql
+++ b/tests/test_flows/raw_sql_scripts/mssql/prep/more_tables.sql
@@ -29,4 +29,6 @@ INNER JOIN (
   FROM {{in_schema}}.raw01 WITH(NOLOCK)
 ) base
   ON apgs.entity = base.entity
+CREATE INDEX raw_start_date ON {{out_schema}}.raw01A (start_date DESC)
+CREATE INDEX raw_start_date_end_date ON {{out_schema}}.raw01A (end_date, start_date DESC)
 

--- a/tests/test_flows/raw_sql_scripts/mssql_pytsql/prep/more_tables.sql
+++ b/tests/test_flows/raw_sql_scripts/mssql_pytsql/prep/more_tables.sql
@@ -29,4 +29,6 @@ INNER JOIN (
   FROM {{in_schema}}.raw01 WITH(NOLOCK)
 ) base
   ON apgs.entity = base.entity
+CREATE INDEX raw_start_date ON {{out_schema}}.raw01A (start_date DESC)
+CREATE INDEX raw_start_date_end_date ON {{out_schema}}.raw01A (end_date, start_date DESC)
 

--- a/tests/test_flows/raw_sql_scripts/mssql_pytsql_isolate/prep/more_tables.sql
+++ b/tests/test_flows/raw_sql_scripts/mssql_pytsql_isolate/prep/more_tables.sql
@@ -29,4 +29,5 @@ INNER JOIN (
   FROM {{in_schema}}.raw01 WITH(NOLOCK)
 ) base
   ON apgs.entity = base.entity
-
+CREATE INDEX raw_start_date ON {{out_schema}}.raw01A (start_date DESC)
+CREATE INDEX raw_start_date_end_date ON {{out_schema}}.raw01A (end_date, start_date DESC)

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+import sqlalchemy as sa
+
+from pydiverse.pipedag import Flow, Stage, Table, materialize
+from pydiverse.pipedag.context import RunContext, StageLockContext
+from pydiverse.pipedag.util.config import PipedagConfig
+
+from tests.util import select_as, tasks_library as m
+from tests.fixtures.instance import *
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        m.simple_dataframe_with_pk,
+        m.simple_dataframe_with_pk2,
+        m.simple_dataframe_with_index,
+        m.simple_dataframe_with_indexes,
+    ],
+)
+def test_materialize_table_with_indexes(task):
+    with Flow("flow") as f:
+        with Stage("stage"):
+            x = task()
+
+            m.assert_table_equal(x, x)
+
+    assert f.run().successful

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -15,10 +15,16 @@ from tests.fixtures.instance import *
 @pytest.mark.parametrize(
     "task",
     [
+        m.simple_dataframe,
         m.simple_dataframe_with_pk,
         m.simple_dataframe_with_pk2,
         m.simple_dataframe_with_index,
         m.simple_dataframe_with_indexes,
+        m.simple_lazy_table,
+        m.simple_lazy_table_with_pk,
+        m.simple_lazy_table_with_pk2,
+        m.simple_lazy_table_with_index,
+        m.simple_lazy_table_with_indexes,
     ],
 )
 def test_materialize_table_with_indexes(task):

--- a/tests/util/tasks_library.py
+++ b/tests/util/tasks_library.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pandas as pd
 
 from pydiverse.pipedag import Blob, Table, materialize
+import sqlalchemy as sa
 
 
 @materialize(input_type=pd.DataFrame)
@@ -99,6 +100,44 @@ def simple_dataframe_with_indexes():
         }
     )
     return Table(df, primary_key=["col1"], indexes=[["col2"], ["col2", "col1"]])
+
+
+def _get_df_query():
+    unions = [
+        sa.select([sa.literal(i).label("col1"), sa.literal(str(i)).label("col2")])
+        for i in range(4)
+    ]
+    return unions[0].union_all(*unions[1:])
+
+
+@materialize(lazy=True)
+def simple_lazy_table():
+    query = _get_df_query()
+    return Table(query)
+
+
+@materialize(lazy=True)
+def simple_lazy_table_with_pk():
+    query = _get_df_query()
+    return Table(query, primary_key="col1")
+
+
+@materialize(lazy=True)
+def simple_lazy_table_with_pk2():
+    query = _get_df_query()
+    return Table(query, primary_key=["col1", "col2"])
+
+
+@materialize(lazy=True)
+def simple_lazy_table_with_index():
+    query = _get_df_query()
+    return Table(query, primary_key=["col1"], indexes=[["col2"]])
+
+
+@materialize(lazy=True)
+def simple_lazy_table_with_indexes():
+    query = _get_df_query()
+    return Table(query, indexes=[["col2"], ["col2", "col1"]])
 
 
 @materialize

--- a/tests/util/tasks_library.py
+++ b/tests/util/tasks_library.py
@@ -58,6 +58,50 @@ def simple_dataframe():
 
 
 @materialize
+def simple_dataframe_with_pk():
+    df = pd.DataFrame(
+        {
+            "col1": [0, 1, 2, 3],
+            "col2": ["0", "1", "2", "3"],
+        }
+    )
+    return Table(df, primary_key="col1")
+
+
+@materialize
+def simple_dataframe_with_pk2():
+    df = pd.DataFrame(
+        {
+            "col1": [0, 1, 2, 3],
+            "col2": ["0", "1", "2", "3"],
+        }
+    )
+    return Table(df, primary_key=["col1", "col2"])
+
+
+@materialize
+def simple_dataframe_with_index():
+    df = pd.DataFrame(
+        {
+            "col1": [0, 1, 2, 3],
+            "col2": ["0", "1", "2", "3"],
+        }
+    )
+    return Table(df, primary_key=["col1"], indexes=[["col2"]])
+
+
+@materialize
+def simple_dataframe_with_indexes():
+    df = pd.DataFrame(
+        {
+            "col1": [0, 1, 2, 3],
+            "col2": ["0", "1", "2", "3"],
+        }
+    )
+    return Table(df, primary_key=["col1"], indexes=[["col2"], ["col2", "col1"]])
+
+
+@materialize
 def pd_dataframe(data: dict[str, list]):
     df = pd.DataFrame(data)
     return Table(df)


### PR DESCRIPTION
We already had a primary_key parameter to Table constructor, but it was not implemented. And it is non-trivial to get that to work with postgres, mssql, and ibm_db_sa...

# Checklist

- [x] Added a `CHANGELOG.rst` entry
