### PR TITLE
Fix primary key / index with same column on different tables within schema

### DIFF
--- a/src/pydiverse/pipedag/backend/table/util/sql_ddl.py
+++ b/src/pydiverse/pipedag/backend/table/util/sql_ddl.py
@@ -638,7 +638,10 @@ def visit_add_primary_key(add_primary_key: AddPrimaryKey, compiler, **kw):
     pk_name = compiler.preparer.quote_identifier(
         add_primary_key.name
         if add_primary_key.name is not None
-        else "pk_" + "_".join(add_primary_key.key)
+        else "pk_"
+        + "_".join([c.lower() for c in add_primary_key.key])
+        + "_"
+        + add_primary_key.table_name.lower()
     )
     cols = ",".join(
         [compiler.preparer.quote_identifier(col) for col in add_primary_key.key]
@@ -656,7 +659,10 @@ def visit_add_primary_key(add_primary_key: AddPrimaryKey, compiler, **kw):
     pk_name = compiler.preparer.quote_identifier(
         add_primary_key.name
         if add_primary_key.name is not None
-        else "pk_" + "_".join(add_primary_key.key)
+        else "pk_"
+        + "_".join([c.lower() for c in add_primary_key.key])
+        + "_"
+        + add_primary_key.table_name.lower()
     )
     cols = ",".join(
         [compiler.preparer.quote_identifier(col) for col in add_primary_key.key]
@@ -680,7 +686,10 @@ def visit_add_primary_key(add_primary_key: AddPrimaryKey, compiler, **kw):
     pk_name = compiler.preparer.quote_identifier(
         add_primary_key.name
         if add_primary_key.name is not None
-        else "pk_" + "_".join(add_primary_key.key)
+        else "pk_"
+        + "_".join([c.lower() for c in add_primary_key.key])
+        + "_"
+        + add_primary_key.table_name.lower()
     )
     cols = ",".join(
         [
@@ -700,7 +709,10 @@ def visit_add_index(add_index: AddIndex, compiler, **kw):
     index_name = compiler.preparer.quote_identifier(
         add_index.name
         if add_index.name is not None
-        else "idx_" + "_".join(add_index.index)
+        else "idx_"
+        + "_".join([c.lower() for c in add_index.index])
+        + "_"
+        + add_index.table_name.lower()
     )
     cols = ",".join(
         [compiler.preparer.quote_identifier(col) for col in add_index.index]
@@ -718,7 +730,10 @@ def visit_add_index(add_index: AddIndex, compiler, **kw):
     index_name = compiler.preparer.quote_identifier(
         add_index.name
         if add_index.name is not None
-        else "idx_" + "_".join(add_index.index)
+        else "idx_"
+        + "_".join([c.lower() for c in add_index.index])
+        + "_"
+        + add_index.table_name.lower()
     )
     cols = ",".join(
         [compiler.preparer.quote_identifier(col) for col in add_index.index]
@@ -739,7 +754,10 @@ def visit_add_index(add_index: AddIndex, compiler, **kw):
     index_name = compiler.preparer.quote_identifier(
         add_index.name
         if add_index.name is not None
-        else "idx_" + "_".join(add_index.index)
+        else "idx_"
+        + "_".join([c.lower() for c in add_index.index])
+        + "_"
+        + add_index.table_name.lower()
     )
     cols = ",".join(
         [

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -18,6 +18,7 @@ from tests.fixtures.instance import *
         m.simple_dataframe_with_pk2,
         m.simple_dataframe_with_index,
         m.simple_dataframe_with_indexes,
+        m.simple_dataframes_with_indexes,
         m.simple_lazy_table,
         m.simple_lazy_table_with_pk,
         m.simple_lazy_table_with_pk2,

--- a/tests/util/tasks_library.py
+++ b/tests/util/tasks_library.py
@@ -102,6 +102,24 @@ def simple_dataframe_with_indexes():
     return Table(df, primary_key=["col1"], indexes=[["col2"], ["col2", "col1"]])
 
 
+@materialize(nout=2)
+def simple_dataframes_with_indexes_task():
+    df = pd.DataFrame(
+        {
+            "col1": [0, 1, 2, 3],
+            "col2": ["0", "1", "2", "3"],
+        }
+    )
+    return Table(
+        df, "dfA", primary_key=["col1"], indexes=[["col2"], ["col2", "col1"]]
+    ), Table(df, "dfB", primary_key=["col1"], indexes=[["col2"], ["col2", "col1"]])
+
+
+def simple_dataframes_with_indexes():
+    res, _ = simple_dataframes_with_indexes_task()
+    return res
+
+
 def _get_df_query():
     unions = [
         sa.select([sa.literal(i).label("col1"), sa.literal(str(i)).label("col2")])


### PR DESCRIPTION
We have a bug that primary/index names are not separated per table in many database targets. This PR fixes it by adding table name to index names.

# Checklist

- [ ] Added a `CHANGELOG.rst` entry
