### PR TITLE
Speed up performance for DB2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Changelog
 ------------------
 
 - added option avoid_drop_create_schema to table store configuration
+- improve performance when working with IBM DB2 dialect
 
 0.2.1 (2022-01-15)
 ------------------

--- a/src/pydiverse/pipedag/backend/table/dict.py
+++ b/src/pydiverse/pipedag/backend/table/dict.py
@@ -140,7 +140,9 @@ class PandasTableHook(TableHook[DictTableStore]):
         return type_ == pd.DataFrame
 
     @classmethod
-    def materialize(cls, store, table: Table[pd.DataFrame], stage_name):
+    def materialize(
+        cls, store, table: Table[pd.DataFrame], stage_name, input_tables: list[Table]
+    ):
         if table.name is not None:
             table.obj.attrs["name"] = table.name
         store.store[stage_name][table.name] = table.obj
@@ -176,7 +178,9 @@ class PydiverseTransformTableHook(TableHook[DictTableStore]):
         return issubclass(type_, PandasTableImpl)
 
     @classmethod
-    def materialize(cls, store, table: Table[pdt.Table], stage_name):
+    def materialize(
+        cls, store, table: Table[pdt.Table], stage_name, input_tables: list[Table]
+    ):
         from pydiverse.transform.core.verbs import collect
 
         table.obj = table.obj >> collect()

--- a/src/pydiverse/pipedag/backend/table/dict.py
+++ b/src/pydiverse/pipedag/backend/table/dict.py
@@ -7,7 +7,7 @@ import pandas as pd
 from pydiverse.pipedag import Stage, Table
 from pydiverse.pipedag.backend.table.base import BaseTableStore, TableHook
 from pydiverse.pipedag.errors import CacheError, StageError
-from pydiverse.pipedag.materialize.core import MaterializingTask
+from pydiverse.pipedag.materialize.core import MaterializingTask, TaskInfo
 from pydiverse.pipedag.materialize.metadata import LazyTableMetadata, TaskMetadata
 
 
@@ -141,8 +141,13 @@ class PandasTableHook(TableHook[DictTableStore]):
 
     @classmethod
     def materialize(
-        cls, store, table: Table[pd.DataFrame], stage_name, input_tables: list[Table]
+        cls,
+        store,
+        table: Table[pd.DataFrame],
+        stage_name,
+        task_info: TaskInfo,
     ):
+        _ = task_info
         if table.name is not None:
             table.obj.attrs["name"] = table.name
         store.store[stage_name][table.name] = table.obj
@@ -179,13 +184,18 @@ class PydiverseTransformTableHook(TableHook[DictTableStore]):
 
     @classmethod
     def materialize(
-        cls, store, table: Table[pdt.Table], stage_name, input_tables: list[Table]
+        cls,
+        store,
+        table: Table[pdt.Table],
+        stage_name,
+        task_info: TaskInfo,
     ):
+        _ = task_info
         from pydiverse.transform.core.verbs import collect
 
         table.obj = table.obj >> collect()
         # noinspection PyTypeChecker
-        return PandasTableHook.materialize(store, table, stage_name)
+        return PandasTableHook.materialize(store, table, stage_name, task_info)
 
     @classmethod
     def retrieve(cls, store, table, stage_name, as_type):

--- a/src/pydiverse/pipedag/context/run_context.py
+++ b/src/pydiverse/pipedag/context/run_context.py
@@ -220,9 +220,11 @@ class RunContextServer(IPCServer):
                 self.stage_state[stage_id] = transition
                 return True
 
+        self.logger.debug("Waiting for stage transition...")
         # Wait until transition is over
         while self.stage_state[stage_id] == transition:
             time.sleep(0.01)
+        self.logger.debug("Waiting completed")
 
         # Check if transition was successful
         with self.stage_state_lock:

--- a/src/pydiverse/pipedag/materialize/core.py
+++ b/src/pydiverse/pipedag/materialize/core.py
@@ -183,12 +183,12 @@ class MaterializationWrapper:
                     return task_cache_info.get_cached_output()
 
             # Not found in cache / lazy -> Evaluate Function
-            args, kwargs = store.dematerialize_task_inputs(
+            args, kwargs, input_tables = store.dematerialize_task_inputs(
                 task, bound.args, bound.kwargs
             )
 
             result = self.fn(*args, **kwargs)
-            result = store.materialize_task(task, task_cache_info, result)
+            result = store.materialize_task(task, task_cache_info, result, input_tables)
 
             # Delete underlying objects from result (after materializing them)
             def obj_del_mutator(x):

--- a/src/pydiverse/pipedag/materialize/store.py
+++ b/src/pydiverse/pipedag/materialize/store.py
@@ -11,9 +11,8 @@ from pydiverse.pipedag._typing import Materializable
 from pydiverse.pipedag.context import ConfigContext, RunContext
 from pydiverse.pipedag.context.run_context import StageState
 from pydiverse.pipedag.errors import DuplicateNameError, StageError
-from pydiverse.pipedag.materialize.cache import TaskCacheInfo
 from pydiverse.pipedag.materialize.container import RawSql
-from pydiverse.pipedag.materialize.core import MaterializingTask
+from pydiverse.pipedag.materialize.core import MaterializingTask, TaskInfo
 from pydiverse.pipedag.materialize.metadata import TaskMetadata
 from pydiverse.pipedag.materialize.util import json as json_util
 from pydiverse.pipedag.util import Disposable, deep_map
@@ -123,7 +122,7 @@ class PipeDAGStore(Disposable):
         task: MaterializingTask,
         args: tuple[Materializable],
         kwargs: dict[str, Materializable],
-    ) -> tuple[tuple, dict]:
+    ) -> tuple[tuple, dict, list[Table]]:
         """Loads the inputs for a task from the storage backends
 
         Traverses the function arguments and replaces all `Table` and
@@ -152,9 +151,8 @@ class PipeDAGStore(Disposable):
     def materialize_task(
         self,
         task: MaterializingTask,
-        task_cache_info: TaskCacheInfo,
+        task_info: TaskInfo,
         value: Materializable,
-        input_tables: list[Table],
     ) -> Materializable:
         """Stores the output of a task in the backend
 
@@ -164,8 +162,7 @@ class PipeDAGStore(Disposable):
 
         :param task: The task instance which produced `value`. Must have
             the correct `cache_key` attribute set.
-        :param task_cache_info: Information about task carried through materialization
-            for CacheManager
+        :param task_info: Information about task carried through materialization
         :param value: The output of the task. Must be materializable; this
             means it can only contain the following object types:
             `dict`, `list`, `tuple`,
@@ -213,7 +210,7 @@ class PipeDAGStore(Disposable):
             if isinstance(x, (Table, RawSql, Blob)):
                 if not task.lazy:
                     # task cache_key is output cache_key for eager tables
-                    x.cache_key = task_cache_info.get_task_cache_key()
+                    x.cache_key = task_info.task_cache_info.get_task_cache_key()
 
                 if isinstance(x, (Table, Blob)):
                     x.stage = stage
@@ -222,7 +219,8 @@ class PipeDAGStore(Disposable):
                     # - If the provided name ends with %%, perform name mangling
                     object_number = next(auto_suffix_counter)
                     auto_suffix = (
-                        f"{task_cache_info.get_task_cache_key()}_{object_number:04d}"
+                        f"{task_info.task_cache_info.get_task_cache_key()}"
+                        f"_{object_number:04d}"
                     )
                     if x.name is None:
                         x.name = task.name + "_" + auto_suffix
@@ -259,15 +257,15 @@ class PipeDAGStore(Disposable):
             can get changed.
             """
             output_json = self.json_encode(m_value)
-            task_cache_info.store_task_metadata(output_json, self.table_store, stage)
+            task_info.task_cache_info.store_task_metadata(
+                output_json, self.table_store, stage
+            )
 
         def store_table(table: Table):
             if task.lazy:
-                self.table_store.store_table_lazy(
-                    table, task, task_cache_info, input_tables
-                )
+                self.table_store.store_table_lazy(table, task, task_info)
             else:
-                self.table_store.store_table(table, input_tables)
+                self.table_store.store_table(table, task, task_info)
 
         # Materialize
         self._check_names(task, tables, blobs)
@@ -277,9 +275,7 @@ class PipeDAGStore(Disposable):
             raw_sqls,
             blobs,
             store_table,
-            lambda raw_sql: self.table_store.store_raw_sql(
-                raw_sql, task, task_cache_info
-            ),
+            lambda raw_sql: self.table_store.store_raw_sql(raw_sql, task, task_info),
             self.blob_store.store_blob,
             store_metadata,
         )

--- a/src/pydiverse/pipedag/util/config.py
+++ b/src/pydiverse/pipedag/util/config.py
@@ -435,7 +435,11 @@ def _pop(d, *path, default=_nil) -> Any:
         return default
 
 
-def setup_structlog(_log_level=logging.INFO, _log_stream=sys.stderr):
+def setup_structlog(
+    _log_level=logging.INFO,
+    _log_stream=sys.stderr,
+    timestamp_format="%Y-%m-%d %H:%M:%S.%f",
+):
     logging.basicConfig(
         stream=_log_stream,
         format="%(asctime)s [%(levelname)s] %(message)s",
@@ -447,7 +451,7 @@ def setup_structlog(_log_level=logging.INFO, _log_stream=sys.stderr):
             structlog.processors.add_log_level,
             structlog.processors.StackInfoRenderer(),
             structlog.dev.set_exc_info,
-            structlog.processors.TimeStamper(),
+            structlog.processors.TimeStamper(fmt=timestamp_format),
             structlog.dev.ConsoleRenderer(),
         ],
         wrapper_class=structlog.make_filtering_bound_logger(_log_level),

--- a/src/pydiverse/pipedag/util/config.py
+++ b/src/pydiverse/pipedag/util/config.py
@@ -159,7 +159,7 @@ class PipedagConfig:
             _set(config, url, "table_store", "url")
 
         # Finally, expand all normal variables
-        self.__expand_variables(inout_config=config)
+        config = self.__expand_variables(config)
 
         # Construct final ConfigContext
         config_context = ConfigContext(
@@ -240,7 +240,8 @@ class PipedagConfig:
             value = expand_environment_variables(value)
             _set(inout_config, value, location)
 
-    def __expand_variables(self, *, inout_config):
+    def __expand_variables(self, config) -> dict[str, Any]:
+        out_config = copy.deepcopy(config)
         locations = [
             ("table_store", "url"),
             ("table_store", "schema_prefix"),
@@ -250,7 +251,7 @@ class PipedagConfig:
         # TODO: Decide on a list of available variables
         variables = {
             "username": getpass.getuser(),
-            "instance_id": inout_config.get("instance_id"),
+            "instance_id": config.get("instance_id"),
             "name": self.name,
         }
 
@@ -259,12 +260,13 @@ class PipedagConfig:
                 variables.pop(key)
 
         for location in locations:
-            value: str = _get(inout_config, location, default=None)
+            value: str = _get(config, location, default=None)
             if value is None:
                 continue
 
             value = expand_variables(value, variables)
-            _set(inout_config, value, location)
+            _set(out_config, value, location)
+        return out_config
 
 
 def find_config(

--- a/tests/util/tasks_library.py
+++ b/tests/util/tasks_library.py
@@ -16,6 +16,16 @@ def noop2(x):
     return x
 
 
+@materialize(input_type=sa.Table, version="1.0")
+def noop_sql(x):
+    return x
+
+
+@materialize(input_type=sa.Table, lazy=True)
+def noop_lazy(x):
+    return x
+
+
 @materialize(nout=2)
 def create_tuple(x, y):
     return x, y


### PR DESCRIPTION
This PR adds a lot of customization for DB2 targets which improve performance:
- lock on table level
- make primary key columns not nullable in the middle of CreateTableAsSelect compilation
- ALIAS instead of VIEWS
...

# Checklist

- [x] Added a `CHANGELOG.rst` entry
