### PR TITLE
Log exceptions produced by tasks, even if `fail_fast=False`

### DIFF
--- a/src/pydiverse/pipedag/core/flow.py
+++ b/src/pydiverse/pipedag/core/flow.py
@@ -258,7 +258,7 @@ class Flow:
                 orchestration_engine = config_context.create_orchestration_engine()
             result = orchestration_engine.run(flow=self, **kwargs)
 
-        fail_fast = config_context.fail_fast if fail_fast is None else fail_fast
+        fail_fast = config_context.fail_fast
         if not result.successful and fail_fast:
             raise result.exception or Exception("Flow run failed")
 

--- a/src/pydiverse/pipedag/core/task.py
+++ b/src/pydiverse/pipedag/core/task.py
@@ -57,7 +57,7 @@ class Task:
         self._signature = inspect.signature(fn)
         self._bound_args: inspect.BoundArguments = None  # type: ignore
 
-        self.logger = structlog.get_logger()
+        self.logger = structlog.get_logger(task=self)
         self._visualize_hidden = False
 
     def __repr__(self):
@@ -136,6 +136,7 @@ class Task:
             try:
                 result = self._run(inputs)
             except Exception as e:
+                self.logger.exception("Task failed (raised an exception)")
                 self.did_finish(FinalTaskState.FAILED)
                 raise e
             else:
@@ -166,9 +167,7 @@ class Task:
 
     def did_finish(self, state: FinalTaskState):
         if state == FinalTaskState.COMPLETED:
-            self.logger.info("Task finished successfully", task=self, state=state)
-        else:
-            self.logger.warning("Task failed", task=self, state=state)
+            self.logger.info("Task finished successfully", state=state)
         RunContext.get().did_finish_task(self, state)
 
     def resolve_value(self, task_value: Any):


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

This is a potential fix for #34.

This PR would change the way exceptions get logged, such that whenever a task raises an exception, it gets logged at the `ERROR` level. Previously, it would just log that the task failed (at the `WARNING` level) without logging the specific exception.

![Bildschirmfoto 2023-06-06 um 15 12 11](https://github.com/pydiverse/pydiverse.pipedag/assets/9914734/01d59abb-ac20-497c-8461-43594f60fae2)
