### PR TITLE
Fix tidypolars test.

### DIFF
--- a/src/pydiverse/pipedag/backend/table/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql.py
@@ -1930,8 +1930,8 @@ class TidyPolarsTableHook(TableHook[SQLTableStore]):
     ):
         t = table.obj
         table = table.copy_without_obj()
-        table.obj = t.obj.to_polars()
-        PolarsTableHook.materialize(store, t, stage_name, task_info)
+        table.obj = t.to_polars()
+        PolarsTableHook.materialize(store, table, stage_name, task_info)
 
     @classmethod
     def retrieve(


### PR DESCRIPTION
Unfortunately tidypolars is not up-to-date with new dependencies. Thus we need the following for the test to succeed: poetry run pip install 'sqlalchemy<2'
poetry run pip install 'polars<0.17'

But this fix should improve the test code in any way.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

# Checklist

- [ ] Added a `CHANGELOG.rst` entry
