### PR TITLE
Add support for DuckDB

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ https://semver.org/spec/v2.0.0.html. The most important bits are:
 Changelog
 =========
 
+- add support for DuckDB
 - support execution of subflow
 - store final state of task in flow result object
 - tasks now have a `position_hash` associated with them to identify them purely based on their position (e.g. stage, name and input wiring) inside a flow.

--- a/poetry.lock
+++ b/poetry.lock
@@ -685,6 +685,83 @@ files = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "0.8.1"
+description = "DuckDB embedded database"
+optional = false
+python-versions = "*"
+files = [
+    {file = "duckdb-0.8.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:14781d21580ee72aba1f5dcae7734674c9b6c078dd60470a08b2b420d15b996d"},
+    {file = "duckdb-0.8.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f13bf7ab0e56ddd2014ef762ae4ee5ea4df5a69545ce1191b8d7df8118ba3167"},
+    {file = "duckdb-0.8.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e4032042d8363e55365bbca3faafc6dc336ed2aad088f10ae1a534ebc5bcc181"},
+    {file = "duckdb-0.8.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:31a71bd8f0b0ca77c27fa89b99349ef22599ffefe1e7684ae2e1aa2904a08684"},
+    {file = "duckdb-0.8.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:24568d6e48f3dbbf4a933109e323507a46b9399ed24c5d4388c4987ddc694fd0"},
+    {file = "duckdb-0.8.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:297226c0dadaa07f7c5ae7cbdb9adba9567db7b16693dbd1b406b739ce0d7924"},
+    {file = "duckdb-0.8.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:5792cf777ece2c0591194006b4d3e531f720186102492872cb32ddb9363919cf"},
+    {file = "duckdb-0.8.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:12803f9f41582b68921d6b21f95ba7a51e1d8f36832b7d8006186f58c3d1b344"},
+    {file = "duckdb-0.8.1-cp310-cp310-win32.whl", hash = "sha256:d0953d5a2355ddc49095e7aef1392b7f59c5be5cec8cdc98b9d9dc1f01e7ce2b"},
+    {file = "duckdb-0.8.1-cp310-cp310-win_amd64.whl", hash = "sha256:6e6583c98a7d6637e83bcadfbd86e1f183917ea539f23b6b41178f32f813a5eb"},
+    {file = "duckdb-0.8.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:fad7ed0d4415f633d955ac24717fa13a500012b600751d4edb050b75fb940c25"},
+    {file = "duckdb-0.8.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:81ae602f34d38d9c48dd60f94b89f28df3ef346830978441b83c5b4eae131d08"},
+    {file = "duckdb-0.8.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7d75cfe563aaa058d3b4ccaaa371c6271e00e3070df5de72361fd161b2fe6780"},
+    {file = "duckdb-0.8.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8dbb55e7a3336f2462e5e916fc128c47fe1c03b6208d6bd413ac11ed95132aa0"},
+    {file = "duckdb-0.8.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a6df53efd63b6fdf04657385a791a4e3c4fb94bfd5db181c4843e2c46b04fef5"},
+    {file = "duckdb-0.8.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b188b80b70d1159b17c9baaf541c1799c1ce8b2af4add179a9eed8e2616be96"},
+    {file = "duckdb-0.8.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:5ad481ee353f31250b45d64b4a104e53b21415577943aa8f84d0af266dc9af85"},
+    {file = "duckdb-0.8.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d1d1b1729993611b1892509d21c21628917625cdbe824a61ce891baadf684b32"},
+    {file = "duckdb-0.8.1-cp311-cp311-win32.whl", hash = "sha256:2d8f9cc301e8455a4f89aa1088b8a2d628f0c1f158d4cf9bc78971ed88d82eea"},
+    {file = "duckdb-0.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:07457a43605223f62d93d2a5a66b3f97731f79bbbe81fdd5b79954306122f612"},
+    {file = "duckdb-0.8.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d2c8062c3e978dbcd80d712ca3e307de8a06bd4f343aa457d7dd7294692a3842"},
+    {file = "duckdb-0.8.1-cp36-cp36m-win32.whl", hash = "sha256:fad486c65ae944eae2de0d590a0a4fb91a9893df98411d66cab03359f9cba39b"},
+    {file = "duckdb-0.8.1-cp36-cp36m-win_amd64.whl", hash = "sha256:86fa4506622c52d2df93089c8e7075f1c4d0ba56f4bf27faebde8725355edf32"},
+    {file = "duckdb-0.8.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:60e07a62782f88420046e30cc0e3de842d0901c4fd5b8e4d28b73826ec0c3f5e"},
+    {file = "duckdb-0.8.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f18563675977f8cbf03748efee0165b4c8ef64e0cbe48366f78e2914d82138bb"},
+    {file = "duckdb-0.8.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:16e179443832bea8439ae4dff93cf1e42c545144ead7a4ef5f473e373eea925a"},
+    {file = "duckdb-0.8.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a413d5267cb41a1afe69d30dd6d4842c588256a6fed7554c7e07dad251ede095"},
+    {file = "duckdb-0.8.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:3784680df59eadd683b0a4c2375d451a64470ca54bd171c01e36951962b1d332"},
+    {file = "duckdb-0.8.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:67a1725c2b01f9b53571ecf3f92959b652f60156c1c48fb35798302e39b3c1a2"},
+    {file = "duckdb-0.8.1-cp37-cp37m-win32.whl", hash = "sha256:197d37e2588c5ad063e79819054eedb7550d43bf1a557d03ba8f8f67f71acc42"},
+    {file = "duckdb-0.8.1-cp37-cp37m-win_amd64.whl", hash = "sha256:3843feb79edf100800f5037c32d5d5a5474fb94b32ace66c707b96605e7c16b2"},
+    {file = "duckdb-0.8.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:624c889b0f2d656794757b3cc4fc58030d5e285f5ad2ef9fba1ea34a01dab7fb"},
+    {file = "duckdb-0.8.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fcbe3742d77eb5add2d617d487266d825e663270ef90253366137a47eaab9448"},
+    {file = "duckdb-0.8.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:47516c9299d09e9dbba097b9fb339b389313c4941da5c54109df01df0f05e78c"},
+    {file = "duckdb-0.8.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf1ba718b7522d34399446ebd5d4b9fcac0b56b6ac07bfebf618fd190ec37c1d"},
+    {file = "duckdb-0.8.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e36e35d38a9ae798fe8cf6a839e81494d5b634af89f4ec9483f4d0a313fc6bdb"},
+    {file = "duckdb-0.8.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:23493313f88ce6e708a512daacad13e83e6d1ea0be204b175df1348f7fc78671"},
+    {file = "duckdb-0.8.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1fb9bf0b6f63616c8a4b9a6a32789045e98c108df100e6bac783dc1e36073737"},
+    {file = "duckdb-0.8.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:12fc13ecd5eddd28b203b9e3999040d3a7374a8f4b833b04bd26b8c5685c2635"},
+    {file = "duckdb-0.8.1-cp38-cp38-win32.whl", hash = "sha256:a12bf4b18306c9cb2c9ba50520317e6cf2de861f121d6f0678505fa83468c627"},
+    {file = "duckdb-0.8.1-cp38-cp38-win_amd64.whl", hash = "sha256:e4e809358b9559c00caac4233e0e2014f3f55cd753a31c4bcbbd1b55ad0d35e4"},
+    {file = "duckdb-0.8.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7acedfc00d97fbdb8c3d120418c41ef3cb86ef59367f3a9a30dff24470d38680"},
+    {file = "duckdb-0.8.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:99bfe264059cdc1e318769103f656f98e819cd4e231cd76c1d1a0327f3e5cef8"},
+    {file = "duckdb-0.8.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:538b225f361066231bc6cd66c04a5561de3eea56115a5dd773e99e5d47eb1b89"},
+    {file = "duckdb-0.8.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae0be3f71a18cd8492d05d0fc1bc67d01d5a9457b04822d025b0fc8ee6efe32e"},
+    {file = "duckdb-0.8.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cd82ba63b58672e46c8ec60bc9946aa4dd7b77f21c1ba09633d8847ad9eb0d7b"},
+    {file = "duckdb-0.8.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:780a34559aaec8354e83aa4b7b31b3555f1b2cf75728bf5ce11b89a950f5cdd9"},
+    {file = "duckdb-0.8.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:01f0d4e9f7103523672bda8d3f77f440b3e0155dd3b2f24997bc0c77f8deb460"},
+    {file = "duckdb-0.8.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:31f692decb98c2d57891da27180201d9e93bb470a3051fcf413e8da65bca37a5"},
+    {file = "duckdb-0.8.1-cp39-cp39-win32.whl", hash = "sha256:e7fe93449cd309bbc67d1bf6f6392a6118e94a9a4479ab8a80518742e855370a"},
+    {file = "duckdb-0.8.1-cp39-cp39-win_amd64.whl", hash = "sha256:81d670bc6807672f038332d9bf587037aabdd741b0810de191984325ed307abd"},
+    {file = "duckdb-0.8.1.tar.gz", hash = "sha256:a54d37f4abc2afc4f92314aaa56ecf215a411f40af4bffe1e86bd25e62aceee9"},
+]
+
+[[package]]
+name = "duckdb-engine"
+version = "0.7.3"
+description = "SQLAlchemy driver for duckdb"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "duckdb_engine-0.7.3-py3-none-any.whl", hash = "sha256:b2dffe1607e87c6bc9d2afd4c43f53f9fc45add8b3c86d276ccbf6ae16cbfcca"},
+    {file = "duckdb_engine-0.7.3.tar.gz", hash = "sha256:a4da04ae3e6bbce8af611b17e09b15212107c8f7871b876a358edfed313ad27d"},
+]
+
+[package.dependencies]
+duckdb = ">=0.4.0"
+numpy = "*"
+sqlalchemy = ">=1.3.22"
+
+[[package]]
 name = "exceptiongroup"
 version = "1.1.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -1689,13 +1766,13 @@ pytzdata = ">=2020.1"
 
 [[package]]
 name = "platformdirs"
-version = "3.6.0"
+version = "3.7.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.6.0-py3-none-any.whl", hash = "sha256:ffa199e3fbab8365778c4a10e1fbf1b9cd50707de826eb304b50e57ec0cc8d38"},
-    {file = "platformdirs-3.6.0.tar.gz", hash = "sha256:57e28820ca8094678b807ff529196506d7a21e17156cb1cddb3e74cebce54640"},
+    {file = "platformdirs-3.7.0-py3-none-any.whl", hash = "sha256:cfd065ba43133ff103ab3bd10aecb095c2a0035fcd1f07217c9376900d94ba07"},
+    {file = "platformdirs-3.7.0.tar.gz", hash = "sha256:87fbf6473e87c078d536980ba970a472422e94f17b752cfad17024c18876d481"},
 ]
 
 [package.extras]
@@ -1704,13 +1781,13 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-
 
 [[package]]
 name = "pluggy"
-version = "1.0.0"
+version = "1.2.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
-    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+    {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
+    {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
 ]
 
 [package.extras]
@@ -3326,4 +3403,4 @@ zookeeper = ["kazoo"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "0cc00278f63cdafddba44b56234b14d85efa9b3f4a05557ec23cc47cee49b22f"
+content-hash = "49167e9db08fe7c2b71e928aef1abcf272edc97aaeac9fce7970f4299e7425f3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ pre-commit = ">=2.20.0"
 kazoo = ">=2.8.0"
 dask = ">=2022.1.0"
 psycopg2 = ">=2.9.3"
+duckdb = "^0.8.1"
+duckdb-engine = "^0.7.3"
 
 [tool.poetry.group.tests]
 optional = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,12 +3,14 @@ pythonpath = src
 testpaths = tests
 
 markers =
-    postgres: a test that requires postgres
-    mssql: a test that requires mssql
-    ibm_db2: a test that requires ibm_db2
-    pdtransform: a test that requires pydiverse-transform
-    ibis: a test that requires ibis
-    polars: a test that requires polars/tidypolars
+    postgres: a test that requires postgres [SQLTableStore]
+    mssql: a test that requires mssql [SQLTableStore]
+    ibm_db2: a test that requires ibm_db2 [SQLTableStore]
+    duckdb: a test that requires duckdb [SQLTableStore]
+
+    pdtransform: a test that requires pydiverse-transform [TableHook]
+    ibis: a test that requires ibis [TableHook]
+    polars: a test that requires polars/tidypolars [TableHook]
 
     dask: a test that requires dask [DaskEngine]
 

--- a/src/pydiverse/pipedag/backend/table/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import itertools
 import json
 import re
@@ -1794,8 +1795,8 @@ class PandasTableHook(TableHook[SQLTableStore]):
     def _fix_cols(cols: dict[str, Any], dialect_name):
         cols = cols.copy()
         year_cols = []
-        min_date = "1900-01-01"
-        max_date = "2199-12-31"
+        min_date = datetime.datetime(1900, 1, 1, 0, 0, 0)
+        max_date = datetime.datetime(2199, 12, 31, 23, 59, 59)
         for name, col in list(cols.items()):
             if isinstance(col.type, sa.Date) or isinstance(col.type, sa.DateTime):
                 if name + "_year" not in cols:

--- a/src/pydiverse/pipedag/backend/table/util/sql_ddl.py
+++ b/src/pydiverse/pipedag/backend/table/util/sql_ddl.py
@@ -901,6 +901,26 @@ def visit_add_primary_key(add_primary_key: AddPrimaryKey, compiler, **kw):
 
 
 # noinspection SqlDialectInspection
+@compiles(AddPrimaryKey, "duckdb")
+def visit_add_primary_key(add_primary_key: AddPrimaryKey, compiler, **kw):
+    _ = kw
+    table = compiler.preparer.quote_identifier(add_primary_key.table_name)
+    schema = compiler.preparer.format_schema(add_primary_key.schema.get())
+    pk_name = compiler.preparer.quote_identifier(
+        add_primary_key.name
+        if add_primary_key.name is not None
+        else "pk_"
+        + "_".join([c.lower() for c in add_primary_key.key])
+        + "_"
+        + add_primary_key.table_name.lower()
+    )
+    cols = ",".join(
+        [compiler.preparer.quote_identifier(col) for col in add_primary_key.key]
+    )
+    return f"CREATE UNIQUE INDEX {pk_name} ON {schema}.{table} ({cols})"
+
+
+# noinspection SqlDialectInspection
 @compiles(AddPrimaryKey, "mssql")
 def visit_add_primary_key(add_primary_key: AddPrimaryKey, compiler, **kw):
     _ = kw
@@ -1019,6 +1039,7 @@ def visit_add_index(add_index: AddIndex, compiler, **kw):
     return f"CREATE INDEX {schema}.{index_name} ON {schema}.{table} ({cols})"
 
 
+# noinspection SqlDialectInspection
 @compiles(ChangeColumnTypes)
 def visit_change_column_types(change: ChangeColumnTypes, compiler, **kw):
     _ = kw
@@ -1041,6 +1062,30 @@ def visit_change_column_types(change: ChangeColumnTypes, compiler, **kw):
         ]
     )
     return f"ALTER TABLE {schema}.{table} {alter_columns}"
+
+
+# noinspection SqlDialectInspection
+@compiles(ChangeColumnTypes, "duckdb")
+def visit_change_column_types_duckdb(change: ChangeColumnTypes, compiler, **kw):
+    table = compiler.preparer.quote_identifier(change.table_name)
+    schema = compiler.preparer.format_schema(change.schema.get())
+    alter_columns = [
+        f"ALTER COLUMN {compiler.preparer.quote_identifier(col)} SET DATA TYPE"
+        f" {compiler.type_compiler.process(_type)}"
+        for col, _type, nullable in zip(
+            change.column_names, change.column_types, change.nullable
+        )
+    ] + [
+        "ALTER COLUMN"
+        f" {compiler.preparer.quote_identifier(col)}"
+        f" {'SET' if not nullable else 'DROP'} NOT NULL"
+        for col, nullable in zip(change.column_names, change.nullable)
+        if nullable is not None
+    ]
+    statements = [
+        f"ALTER TABLE {schema}.{table} {statement}" for statement in alter_columns
+    ]
+    return join_ddl_statements(statements, compiler, **kw)
 
 
 # noinspection SqlDialectInspection
@@ -1113,7 +1158,7 @@ def visit_change_column_types(change: ChangeColumnTypes, compiler, **kw):
 
 # noinspection SqlDialectInspection
 @compiles(ChangeColumnNullable)
-def visit_change_column_types(change: ChangeColumnNullable, compiler, **kw):
+def visit_change_column_nullable(change: ChangeColumnNullable, compiler, **kw):
     _ = kw
     table = compiler.preparer.quote_identifier(change.table_name)
     schema = compiler.preparer.format_schema(change.schema.get())
@@ -1130,7 +1175,7 @@ def visit_change_column_types(change: ChangeColumnNullable, compiler, **kw):
 
 # noinspection SqlDialectInspection
 @compiles(ChangeColumnNullable, "ibm_db_sa")
-def visit_change_column_types_db2(change: ChangeColumnNullable, compiler, **kw):
+def visit_change_column_nullable(change: ChangeColumnNullable, compiler, **kw):
     _ = kw
     # DB2 stores capitalized table names but sqlalchemy reflects them lowercase
     change = copy.deepcopy(change)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
 
 
 def pytest_addoption(parser):
-    for opt in ["mssql", "ibm_db2", "pdtransform", "ibis", "polars", "dask"]:
+    for opt in ["mssql", "ibm_db2", "duckdb", "pdtransform", "ibis", "polars", "dask"]:
         parser.addoption(
             "--" + opt,
             action="store_true",
@@ -97,7 +97,7 @@ def pytest_addoption(parser):
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items):
-    for opt in ["mssql", "ibm_db2", "pdtransform", "ibis", "polars", "dask"]:
+    for opt in ["mssql", "ibm_db2", "duckdb", "pdtransform", "ibis", "polars", "dask"]:
         if not config.getoption("--" + opt):
             skip = pytest.mark.skip(reason=f"{opt} not selected")
             for item in items:

--- a/tests/fixtures/instances.py
+++ b/tests/fixtures/instances.py
@@ -19,6 +19,7 @@ INSTANCE_MARKS = {
     "mssql_pytsql": pytest.mark.mssql,
     "ibm_db2": pytest.mark.ibm_db2,
     "ibm_db2_avoid_schema": pytest.mark.ibm_db2,
+    "duckdb": pytest.mark.duckdb,
     "dask_engine": [pytest.mark.dask, pytest.mark.postgres],
 }
 
@@ -27,6 +28,7 @@ DATABASE_INSTANCES = (
     "postgres",
     "mssql",
     "ibm_db2",
+    "duckdb",
 )
 
 # Extended collection of instances
@@ -36,6 +38,7 @@ ALL_INSTANCES = (
     "mssql_pytsql",
     "ibm_db2",
     "ibm_db2_avoid_schema",
+    "duckdb",
 )
 
 

--- a/tests/resources/pipedag.yaml
+++ b/tests/resources/pipedag.yaml
@@ -4,6 +4,7 @@ table_store_connections:
     args:
       # Postgres: this can be used after running `docker-compose up`
       url: "postgresql://{$POSTGRES_USERNAME}:{$POSTGRES_PASSWORD}@127.0.0.1:6543/{instance_id}"
+      create_database_if_not_exists: true
 
   mssql:
     args:
@@ -11,12 +12,18 @@ table_store_connections:
       url: "mssql+pyodbc://{$MSSQL_USERNAME}:{$MSSQL_PASSWORD}@127.0.0.1:1433/master?driver=ODBC+Driver+18+for+SQL+Server&encrypt=no"
       schema_prefix: "{instance_id}_"  # SQL Server needs database.schema
       schema_suffix: ".dbo"   # Alternatively SQL Server databases can be used as schemas with .dbo default schema
+      create_database_if_not_exists: false
 
   ibm_db2:
     args:
       # SQL Server: this can be used after running `docker-compose up`
       url: "db2+ibm_db://db2inst1:password@localhost:50000/testdb"
       schema_prefix: "{instance_id}_"
+      create_database_if_not_exists: false
+
+  duckdb:
+    args:
+      url: "duckdb:///{$TMPDIR}{instance_id}.duckdb"
 
 instances:
   __any__:
@@ -33,9 +40,6 @@ instances:
       table_store_connection: postgres
       class: "pydiverse.pipedag.backend.table.SQLTableStore"
       args:
-        # Postgres: this can be used after running `docker-compose up`
-        create_database_if_not_exists: true
-
         # print select statements before being encapsualted in materialize expressions and tables before writing to
         # database
         print_materialize: true
@@ -92,6 +96,12 @@ instances:
       table_store_connection: ibm_db2
       args:
         avoid_drop_create_schema: true
+
+  duckdb:
+    instance_id: pd_duckdb
+    stage_commit_technique: READ_VIEWS
+    table_store:
+      table_store_connection: duckdb
 
   ## Table Cache Instances
 

--- a/tests/test_cache/test_ignore_fresh_input.py
+++ b/tests/test_cache/test_ignore_fresh_input.py
@@ -257,7 +257,8 @@ def test_blob(mocker):
         child_spy.assert_called_once()
 
 
-@skip_instances("mssql", "mssql_pytsql", "ibm_db2", "ibm_db2_avoid_schema")
+# TODO: Determine exactly why this test only works with postgres
+@skip_instances("mssql", "mssql_pytsql", "ibm_db2", "ibm_db2_avoid_schema", "duckdb")
 def test_raw_sql(mocker):
     cache_value = 0
     raw_value = 0

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -5,7 +5,7 @@ import pytest
 from pydiverse.pipedag import Flow, Stage
 
 # Parameterize all tests in this file with several instance_id configurations
-from tests.fixtures.instances import DATABASE_INSTANCES, with_instances
+from tests.fixtures.instances import DATABASE_INSTANCES, with_instances, skip_instances
 from tests.util import tasks_library as m
 
 pytestmark = [with_instances(DATABASE_INSTANCES)]

--- a/tests/util/tasks_library.py
+++ b/tests/util/tasks_library.py
@@ -188,7 +188,7 @@ def _get_df(data: dict[str, list], use_ext_dtype=False, cap_dates=False):
             data[col] = [dt.datetime.combine(d, dt.time()) for d in data[col]]
         if cap_dates:
             min_datetime = dt.datetime(1900, 1, 1, 0, 0, 0)
-            max_datetime = dt.datetime(2199, 12, 31, 0, 0, 0)
+            max_datetime = dt.datetime(2199, 12, 31, 23, 59, 59)
             min_date = dt.date(1900, 1, 1)
             max_date = dt.date(2199, 12, 31)
             if type(data[col][0]) == dt.date:

--- a/tests/util/tasks_library.py
+++ b/tests/util/tasks_library.py
@@ -184,8 +184,6 @@ def _get_df(data: dict[str, list], use_ext_dtype=False, cap_dates=False):
     data = data.copy()
     dtypes = {}
     for col in list(data.keys()):
-        if type(data[col][0]) == dt.date:
-            data[col] = [dt.datetime.combine(d, dt.time()) for d in data[col]]
         if cap_dates:
             min_datetime = dt.datetime(1900, 1, 1, 0, 0, 0)
             max_datetime = dt.datetime(2199, 12, 31, 23, 59, 59)
@@ -226,13 +224,13 @@ def pd_dataframe(data: dict[str, list], use_ext_dtype=False, cap_dates=False):
     kwargs = {}
     if not cap_dates:
         kwargs["type_map"] = {
-            col: sa.Date for col, items in data.items() if type(items[0]) in [dt.date]
+            col: sa.Date for col, items in data.items() if isinstance(items[0], dt.date)
         }
         kwargs["type_map"].update(
             {
                 col: sa.DateTime
                 for col, items in data.items()
-                if type(items[0]) in [dt.datetime]
+                if isinstance(items[0], dt.datetime)
             }
         )
     return Table(df, **kwargs)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

DuckDB is quite similar to Postgres, consequently it is quite an easy backend to support.

# Checklist

- [x] Added a `CHANGELOG.rst` entry
