### PR TITLE
Get rid of `ibm_db_sa_fix_name` hack

### DIFF
--- a/src/pydiverse/pipedag/backend/lock/database.py
+++ b/src/pydiverse/pipedag/backend/lock/database.py
@@ -14,7 +14,6 @@ from pydiverse.pipedag.backend.table.util import engine_dispatch
 from pydiverse.pipedag.backend.table.util.sql_ddl import (
     CreateSchema,
     Schema,
-    ibm_db_sa_fix_name,
 )
 from pydiverse.pipedag.errors import LockError
 
@@ -315,12 +314,8 @@ class DB2Lock(Lock):
         self.schema = schema
 
     def acquire(self) -> bool:
-        table = self._engine.dialect.identifier_preparer.quote_identifier(
-            ibm_db_sa_fix_name(self.table)
-        )
-        schema = self._engine.dialect.identifier_preparer.format_schema(
-            ibm_db_sa_fix_name(self.schema)
-        )
+        table = self._engine.dialect.identifier_preparer.quote_identifier(self.table)
+        schema = self._engine.dialect.identifier_preparer.format_schema(self.schema)
 
         # CREATE TABLE IF NOT EXISTS
         with self._engine.begin() as conn:

--- a/src/pydiverse/pipedag/backend/lock/database.py
+++ b/src/pydiverse/pipedag/backend/lock/database.py
@@ -221,16 +221,16 @@ class PostgresLock(Lock):
         self._locked = False
 
     def acquire(self) -> bool:
-        result = self._connection.execute(
-            sa.text(f"SELECT pg_catalog.pg_advisory_lock({self._id})")
+        result = self._connection.exec_driver_sql(
+            f"SELECT pg_catalog.pg_advisory_lock({self._id})"
         ).scalar()
         result = False if result is False else True
         self._locked = result
         return result
 
     def release(self) -> bool:
-        result = self._connection.execute(
-            sa.text(f"SELECT pg_catalog.pg_advisory_unlock({self._id})")
+        result = self._connection.exec_driver_sql(
+            f"SELECT pg_catalog.pg_advisory_unlock({self._id})"
         ).scalar()
         self._locked = False
         return False if result is False else True
@@ -314,20 +314,18 @@ class DB2Lock(Lock):
         self.schema = schema
 
     def acquire(self) -> bool:
-        table = self._engine.dialect.identifier_preparer.quote_identifier(self.table)
+        table = self._engine.dialect.identifier_preparer.quote(self.table)
         schema = self._engine.dialect.identifier_preparer.format_schema(self.schema)
 
         # CREATE TABLE IF NOT EXISTS
         with self._engine.begin() as conn:
-            conn.execute(
-                sa.text(
-                    f"""
-                    BEGIN
-                        DECLARE CONTINUE HANDLER FOR SQLSTATE '42710' BEGIN END;
-                        EXECUTE IMMEDIATE 'CREATE TABLE {schema}.{table} (x int)';
-                    END
-                    """
-                )
+            conn.exec_driver_sql(
+                f"""
+                BEGIN
+                    DECLARE CONTINUE HANDLER FOR SQLSTATE '42710' BEGIN END;
+                    EXECUTE IMMEDIATE 'CREATE TABLE {schema}.{table} (x int)';
+                END
+                """
             )
 
         # LOCK TABLE
@@ -335,8 +333,8 @@ class DB2Lock(Lock):
             self._connection = self._engine.connect()
             self._connection.begin()
 
-        self._connection.execute(
-            sa.text(f"LOCK TABLE {schema}.{table} IN EXCLUSIVE MODE")
+        self._connection.exec_driver_sql(
+            f"LOCK TABLE {schema}.{table} IN EXCLUSIVE MODE"
         )
 
         self._locked = True

--- a/src/pydiverse/pipedag/backend/table/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql.py
@@ -377,17 +377,6 @@ class SQLTableStore(BaseTableStore):
 
         return self._execute(query, conn)
 
-    @engine_dispatch
-    def name_adj(self, name: str):
-        # some dialects need to replace all lowercase names by uppercase because
-        # they create uppercase table names by default
-        return name
-
-    @name_adj.dialect("ibm_db_sa")
-    def _name_adj_ibm_db_sa(self, name: str):
-        # DB2 creates tables uppercase if all lowercase given
-        return name.upper() if name.islower() else name
-
     def add_indexes(
         self, table: Table, schema: Schema, *, early_not_null_possible: bool = False
     ):
@@ -497,20 +486,11 @@ class SQLTableStore(BaseTableStore):
                     time.sleep(retry_iteration * retry_iteration * 1.1)
         self.execute(AddPrimaryKey(table_name, schema, key_columns, name))
 
-    # @add_index.dialect("ibm_db_sa")
-    # def _add_index_ibm_db_sa(
-    #     self, table_name: str, schema: Schema, index: list[str],
-    #     name: str | None = None
-    # ):
-    #     self.execute(AddIndex(table_name, schema, index, name))
-
     def copy_indexes(
         self, src_table: str, src_schema: Schema, dest_table: str, dest_schema: Schema
     ):
         inspector = sa.inspect(self.engine)
-        pk_constraint = inspector.get_pk_constraint(
-            self.name_adj(src_table), schema=self.name_adj(src_schema.get())
-        )
+        pk_constraint = inspector.get_pk_constraint(src_table, schema=src_schema.get())
         if len(pk_constraint["constrained_columns"]) > 0:
             self.add_primary_key(
                 dest_table,
@@ -518,9 +498,7 @@ class SQLTableStore(BaseTableStore):
                 pk_constraint["constrained_columns"],
                 name=pk_constraint["name"],
             )
-        indexes = inspector.get_indexes(
-            self.name_adj(src_table), schema=self.name_adj(src_schema.get())
-        )
+        indexes = inspector.get_indexes(src_table, schema=src_schema.get())
         for index in indexes:
             if len(index["include_columns"]) > 0:
                 self.logger.warning(
@@ -547,9 +525,7 @@ class SQLTableStore(BaseTableStore):
         self, col_names: Iterable[str], table_name: str, schema: Schema
     ):
         inspector = sa.inspect(self.engine)
-        columns = inspector.get_columns(
-            self.name_adj(table_name), schema=self.name_adj(schema.get())
-        )
+        columns = inspector.get_columns(table_name, schema=schema.get())
         types = {d["name"]: d["type"] for d in columns}
         sql_types = [types[col] for col in col_names]
         return sql_types
@@ -690,13 +666,9 @@ class SQLTableStore(BaseTableStore):
                 # Attention: similar code in sql_ddl.py:visit_drop_schema_ibm_db_sa
                 # for drop.cascade=True
                 inspector = sa.inspect(self.engine)
-                for table in inspector.get_table_names(
-                    schema=self.name_adj(transaction_schema.get())
-                ):
+                for table in inspector.get_table_names(schema=transaction_schema.get()):
                     self.execute(DropTable(table, schema=transaction_schema))
-                for view in inspector.get_view_names(
-                    schema=self.name_adj(transaction_schema.get())
-                ):
+                for view in inspector.get_view_names(schema=transaction_schema.get()):
                     self.execute(DropView(view, schema=transaction_schema))
                 self.drop_all_dialect_specific(schema=transaction_schema)
             else:
@@ -972,14 +944,11 @@ class SQLTableStore(BaseTableStore):
 
     def _copy_table(self, table: Table, from_schema: Schema, from_name: str):
         """Copies the table immediately"""
-        has_table = sa.inspect(self.engine).has_table(
-            self.name_adj(from_name), schema=self.name_adj(from_schema.get())
-        )
+        inspector = sa.inspect(self.engine)
+        has_table = inspector.has_table(from_name, schema=from_schema.get())
 
         if not has_table:
-            available_tables = sa.inspect(self.engine).get_table_names(
-                self.name_adj(from_schema.get())
-            )
+            available_tables = inspector.get_table_names(from_schema.get())
             msg = (
                 f"Can't copy table '{from_name}' (schema: '{from_schema}') to "
                 f"transaction because no such table exists.\n"
@@ -1020,13 +989,10 @@ class SQLTableStore(BaseTableStore):
         """
         assert from_schema == self.get_schema(table.stage.name)
 
-        has_table = sa.inspect(self.engine).has_table(
-            self.name_adj(from_name), schema=self.name_adj(from_schema.get())
-        )
+        inspector = sa.inspect(self.engine)
+        has_table = inspector.has_table(from_name, schema=from_schema.get())
         if not has_table:
-            available_tables = sa.inspect(self.engine).get_table_names(
-                self.name_adj(from_schema.get())
-            )
+            available_tables = inspector.get_table_names(from_schema.get())
             msg = (
                 f"Can't deferred copy table '{from_name}' (schema: '{from_schema}') to "
                 f"transaction because no such table exists.\n"
@@ -1139,14 +1105,12 @@ class SQLTableStore(BaseTableStore):
         """
         _ = include_everything  # not used in this implementation
         inspector = sa.inspect(self.engine)
-        return inspector.get_view_names(self.name_adj(schema))
+        return inspector.get_view_names(schema)
 
     @get_view_names.dialect("mssql")
     def _get_view_names_mssql(self, schema: str, *, include_everything=False):
         if not include_everything:
-            return self.get_view_names.original(
-                self, schema, include_everything=include_everything
-            )
+            return self.get_view_names.original(self, schema)
         return list(self._get_mssql_sql_modules(schema).keys())
 
     # noinspection SqlDialectInspection
@@ -1512,7 +1476,7 @@ class SQLTableStore(BaseTableStore):
         inspector = sa.inspect(self.engine)
         schema = self.get_schema(stage.transaction_name).get()
 
-        table_names = inspector.get_table_names(self.name_adj(schema))
+        table_names = inspector.get_table_names(schema)
         view_names = self.get_view_names(schema, include_everything=include_everything)
 
         return table_names + view_names

--- a/src/pydiverse/pipedag/backend/table/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql.py
@@ -663,11 +663,10 @@ class SQLTableStore(BaseTableStore):
     @drop_all_dialect_specific.dialect("ibm_db_sa")
     def _drop_all_dialect_specific_ibm_db_sa(self, schema: Schema):
         with self.engine_connect() as conn:
-            name = schema.get()
             alias_names = conn.execute(
                 sa.text(
                     "SELECT NAME FROM SYSIBM.SYSTABLES WHERE CREATOR ="
-                    f" '{name}' and TYPE='A'"
+                    f" '{schema.get()}' and TYPE='A'"
                 )
             ).all()
         alias_names = [row[0] for row in alias_names]

--- a/src/pydiverse/pipedag/backend/table/sql_hooks.py
+++ b/src/pydiverse/pipedag/backend/table/sql_hooks.py
@@ -23,7 +23,6 @@ from pydiverse.pipedag.backend.table.util.sql_ddl import (
     ChangeTableLogged,
     CreateTableAsSelect,
     Schema,
-    ibm_db_sa_fix_name,
 )
 from pydiverse.pipedag.materialize import Table
 from pydiverse.pipedag.materialize.core import TaskInfo
@@ -342,7 +341,7 @@ class PandasTableHook(TableHook[SQLTableStore]):
             dtypes.update(table.type_map)
 
         df.to_sql(
-            ibm_db_sa_fix_name(table.name),
+            table.name,
             engine,
             schema=schema.get(),
             index=False,

--- a/src/pydiverse/pipedag/backend/table/util/sql_reflection.py
+++ b/src/pydiverse/pipedag/backend/table/util/sql_reflection.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+
+class PipedagDB2Reflection:
+    @staticmethod
+    def get_alias_names(engine: sa.Engine, schema: str) -> list[str]:
+        """Returns all aliases in a schema"""
+
+        schema = engine.dialect.denormalize_name(schema)
+
+        query = f"""
+        SELECT TABNAME
+        FROM SYSCAT.TABLES
+        WHERE TABSCHEMA = '{schema}' AND TYPE = 'A'
+        """
+
+        with engine.connect() as conn:
+            aliases = conn.exec_driver_sql(query).scalars().all()
+
+        aliases = [engine.dialect.normalize_name(name) for name in aliases]
+        return list(aliases)
+
+    @staticmethod
+    def resolve_alias(engine: sa.Engine, name: str, schema: str) -> tuple[str, str]:
+        """Recursively resolves an alias
+
+        :returns: A tuple (table_name, schema)
+        """
+
+        _schema = engine.dialect.denormalize_name(schema)
+        _name = engine.dialect.denormalize_name(name)
+
+        # Recursive CTE query to resolve alias
+        query = f"""
+        WITH aliases (TABSCHEMA, TABNAME, BASE_TABSCHEMA, BASE_TABNAME, LEVEL) as
+            (SELECT a.TABSCHEMA, a.TABNAME, a.BASE_TABSCHEMA, a.BASE_TABNAME, 1
+                    FROM SYSCAT.TABLES a
+                    WHERE TABSCHEMA = '{_schema}'
+                      AND TABNAME = '{_name}'
+                      AND TYPE = 'A'
+             UNION ALL
+             SELECT b.TABSCHEMA, b.TABNAME, b.BASE_TABSCHEMA, b.BASE_TABNAME, r.LEVEL+1
+                    FROM aliases r, SYSCAT.TABLES b
+                    WHERE r.BASE_TABSCHEMA = b.TABSCHEMA
+                      AND r.BASE_TABNAME = b.TABNAME
+                      AND b.TYPE = 'A'
+                      AND r.LEVEL < 100)
+        SELECT BASE_TABNAME, BASE_TABSCHEMA FROM aliases
+        ORDER BY LEVEL DESC
+        LIMIT 1
+        """
+
+        with engine.connect() as conn:
+            if result := conn.exec_driver_sql(query).one_or_none():
+                return (
+                    engine.dialect.normalize_name(result[0]),
+                    engine.dialect.normalize_name(result[1]),
+                )
+        return name, schema
+
+
+class PipedagMSSqlReflection:
+    @staticmethod
+    def get_alias_names(engine: sa.Engine, schema: str):
+        database, schema_only = schema.split(".")
+
+        query = f"""
+        SELECT syn.name
+        FROM sys.synonyms AS syn
+        LEFT JOIN sys.schemas AS schem
+               ON syn.schema_id = schem.schema_id
+        WHERE schem.name = '{schema_only}'
+        """
+
+        with engine.connect() as conn:
+            conn.exec_driver_sql(f"USE [{database}]")
+            result = conn.exec_driver_sql(query).scalars().all()
+        return result
+
+    @staticmethod
+    def resolve_alias(
+        engine: sa.Engine, name: str, schema: str
+    ) -> tuple[str, str] | tuple[None, None]:
+        from sqlalchemy.dialects.mssql.base import _schema_elements
+
+        database, schema_only = schema.split(".")
+
+        query = f"""
+        SELECT syn.base_object_name
+        FROM sys.synonyms AS syn
+        LEFT JOIN sys.schemas AS schem
+               ON syn.schema_id = schem.schema_id
+        WHERE schem.name = '{schema_only}'
+          AND syn.name = '{name}'
+          AND syn.type = 'SN'
+        """
+
+        with engine.connect() as conn:
+            conn.exec_driver_sql(f"USE [{database}]")
+            base_object_name = conn.exec_driver_sql(query).scalar_one_or_none()
+
+        if base_object_name:
+            owner, table = _schema_elements(base_object_name)
+            dbname, owner = _schema_elements(owner)
+            return table, dbname + "." + owner
+
+        return name, schema


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Our issues with IBM DB2 were caused by using `compiler.preparer.quote_identifier` instead of `compiler.preparer.quote`. Unlike `quote`, `quote_identifier` doesn't check if a name should get quoted or not. Because in SQLAlchemy all lowercase identifiers are viewed as case insensitive ([ref](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table.params.name)), this resulted in our custom DDL statements interacting incorrectly with SQLAlchemy.
