### PR TITLE
Postgres unlogged tables as a materialization detail

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -7,8 +7,8 @@
 - Update install instructions and dependencies to enable DB2 and mssql development on OS X with an `arm64` architecture.
 - Update PR template
 - Run `RUNSTATS` on every DB2 table after creation
-- Add `materialization_details` as an option to `IBMDB2TableStore`. For now DB2 compression and table spaces are supported.
-- Make `unlogged` a materialization detail for Postgres and remove `unlogged_tables` as a parameter for `PostgresTableStore`. This is a breaking change.
+- Add `materialization_details` as an option to `IBMDB2TableStore`. For now DB2 compression, DB2 table spaces are supported and Postgres `unlogged` tables are supported.
+  - For Postgres `unlogged` tables this is a breaking change. The `unlogged_tables` option does not exist anymore. Instead, use `materialization_details: __any__: unlogged: true`.
 
 ## 0.6.6 (2023-08-17)
 - Implement support for loading polars dataframes from DuckDB.

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -7,7 +7,8 @@
 - Update install instructions and dependencies to enable DB2 and mssql development on OS X with an `arm64` architecture.
 - Update PR template
 - Run `RUNSTATS` on every DB2 table after creation
-- Add `materialization_details` as an option to `IBMDB2TableStore`. For now DB2 compression and table spaces are supported. 
+- Add `materialization_details` as an option to `IBMDB2TableStore`. For now DB2 compression and table spaces are supported.
+- Make `unlogged` a materialization detail for Postgres and remove `unlogged_tables` as a parameter for `PostgresTableStore`. This is a breaking change.
 
 ## 0.6.6 (2023-08-17)
 - Implement support for loading polars dataframes from DuckDB.

--- a/pipedag.yaml
+++ b/pipedag.yaml
@@ -20,7 +20,7 @@ table_store_connections:
       default_materialization_details: "no_compression"
       materialization_details:
         __any__:
-          compression: ["COMPRESS YES ADAPTIVE"]
+          compression: [ "COMPRESS YES ADAPTIVE" ]
         no_compression:
           compression: ""
         value_compression:
@@ -28,7 +28,7 @@ table_store_connections:
         static_compression:
           compression: "COMPRESS YES STATIC"
         adaptive_value_compression:
-          compression: ["COMPRESS YES ADAPTIVE", "VALUE COMPRESSION"]
+          compression: [ "COMPRESS YES ADAPTIVE", "VALUE COMPRESSION" ]
         table_space:
           table_space_data: "S1"
           table_space_index: "S2"
@@ -81,15 +81,15 @@ instances:
     instance_id: pd_postgres
     table_store:
       table_store_connection: postgres
-      args:
-        unlogged_tables: false
 
   postgres_unlogged:
     instance_id: pd_postgres_unlogged
     table_store:
       table_store_connection: postgres
       args:
-        unlogged_tables: true
+        materialization_details:
+          __any__:
+            unlogged: true
 
   mssql:
     instance_id: pd_mssql

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/ibm_db2.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/ibm_db2.py
@@ -78,38 +78,12 @@ class IBMDB2TableStore(SQLTableStore):
     SQLTableStore that supports `IBM Db2 <https://www.ibm.com/products/db2>`_.
     Requires `ibm-db-sa <https://pypi.org/project/ibm-db-sa/>`_ to be installed.
 
-    In addition to the arguments of
-    :py:class:`SQLTableStore <pydiverse.pipedag.backend.table.SQLTableStore>`,
-    it also takes the following arguments:
-
-    :param materialization_details:
-        A dictionary with each entry describing a tag for materialization details of
-        the table store.
-    :param default_materialization_details:
-        The materialization_details that will be used if materialization_details
-        is not specified on table level. If not set, the ``__any__`` tag (if specified)
-        will be used.
+    Takes the same arguments as
+    :py:class:`SQLTableStore <pydiverse.pipedag.backend.table.SQLTableStore>`
     """
 
     _dialect_name = "ibm_db_sa"
-
-    def __init__(
-        self,
-        *args,
-        materialization_details: dict[str, dict[str | list[str]]] = None,
-        default_materialization_details: str = "__any__",
-        **kwargs,
-    ):
-        super().__init__(*args, **kwargs)
-        self.materialization_details = (
-            IBMDB2MaterializationDetails.create_materialization_details_dict(
-                materialization_details,
-                self.strict_materialization_details,
-                default_materialization_details,
-                self.logger,
-            )
-        )
-        self.default_materialization_details = default_materialization_details
+    _materialization_details_class = IBMDB2MaterializationDetails
 
     def add_primary_key(
         self,

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/ibm_db2.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/ibm_db2.py
@@ -83,7 +83,6 @@ class IBMDB2TableStore(SQLTableStore):
     """
 
     _dialect_name = "ibm_db_sa"
-    _materialization_details_class = IBMDB2MaterializationDetails
 
     def add_primary_key(
         self,

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/ibm_db2.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/ibm_db2.py
@@ -129,6 +129,22 @@ class IBMDB2TableStore(SQLTableStore):
     def resolve_alias(self, table, schema):
         return PipedagDB2Reflection.resolve_alias(self.engine, table, schema)
 
+    def check_materialization_details_supported(self, label: str | None) -> None:
+        _ = label
+        return
+
+    def _set_materialization_details(
+        self, materialization_details: dict[str, dict[str | list[str]]] | None
+    ) -> None:
+        self.materialization_details = (
+            IBMDB2MaterializationDetails.create_materialization_details_dict(
+                materialization_details,
+                self.strict_materialization_details,
+                self.default_materialization_details,
+                self.logger,
+            )
+        )
+
     def _get_compression(
         self, materialization_details_label: str | None
     ) -> str | list[str] | None:

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/postgres.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/postgres.py
@@ -67,6 +67,22 @@ class PostgresTableStore(SQLTableStore):
             self.logger,
         )
 
+    def check_materialization_details_supported(self, label: str | None) -> None:
+        _ = label
+        return
+
+    def _set_materialization_details(
+        self, materialization_details: dict[str, dict[str | list[str]]] | None
+    ) -> None:
+        self.materialization_details = (
+            PostgresMaterializationDetails.create_materialization_details_dict(
+                materialization_details,
+                self.strict_materialization_details,
+                self.default_materialization_details,
+                self.logger,
+            )
+        )
+
 
 @PostgresTableStore.register_table()
 class SQLAlchemyTableHook(SQLAlchemyTableHook):

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/postgres.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/postgres.py
@@ -52,7 +52,6 @@ class PostgresTableStore(SQLTableStore):
     """
 
     _dialect_name = "postgresql"
-    _materialization_details_class = PostgresMaterializationDetails
 
     def _init_database(self):
         self._init_database_with_database("postgres", {"isolation_level": "AUTOCOMMIT"})

--- a/src/pydiverse/pipedag/backend/table/sql/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql/sql.py
@@ -5,11 +5,10 @@ import textwrap
 import warnings
 from collections.abc import Iterable
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, TypeVar
 
 import sqlalchemy as sa
 import sqlalchemy.exc
-import sqlalchemy.sql.elements
 
 from pydiverse.pipedag import Stage, Table
 from pydiverse.pipedag.backend.table.base import BaseTableStore
@@ -35,13 +34,20 @@ from pydiverse.pipedag.context.run_context import DeferredTableStoreOp
 from pydiverse.pipedag.errors import CacheError
 from pydiverse.pipedag.materialize.container import RawSql
 from pydiverse.pipedag.materialize.core import MaterializingTask
-from pydiverse.pipedag.materialize.details import resolve_materialization_details_label
+from pydiverse.pipedag.materialize.details import (
+    BaseMaterializationDetails,
+    resolve_materialization_details_label,
+)
 from pydiverse.pipedag.materialize.metadata import (
     LazyTableMetadata,
     RawSqlMetadata,
     TaskMetadata,
 )
 from pydiverse.pipedag.util.hashing import stable_hash
+
+_materialization_details_subclass = TypeVar(
+    "_materialization_details_subclass", bound=BaseMaterializationDetails
+)
 
 
 class SQLTableStore(BaseTableStore):
@@ -151,6 +157,16 @@ class SQLTableStore(BaseTableStore):
             - a table references a ``materialization_details`` tag that is not defined
               in the config.
         If ``False``: Log an error instead of raising an exception
+
+    :param materialization_details:
+        A dictionary with each entry describing a tag for materialization details of
+        the table store. See subclasses of :py:class:`BaseMaterializationDetails
+         <pydiverse.pipedag.materialize.details.BaseMaterializationDetails>`
+        for details.
+    :param default_materialization_details:
+        The materialization_details that will be used if materialization_details
+        is not specified on table level. If not set, the ``__any__`` tag (if specified)
+        will be used.
     """
 
     METADATA_SCHEMA = "pipedag_metadata"
@@ -158,6 +174,7 @@ class SQLTableStore(BaseTableStore):
 
     __registered_dialects: dict[str, type[SQLTableStore]] = {}
     _dialect_name: str
+    _materialization_details_class: _materialization_details_subclass | None = None
 
     def __new__(cls, engine_url: str, *args, **kwargs):
         if cls != SQLTableStore:
@@ -187,21 +204,16 @@ class SQLTableStore(BaseTableStore):
         print_sql: bool = False,
         no_db_locking: bool = True,
         strict_materialization_details: bool = True,
-        **kwargs,
+        materialization_details: dict[str, dict[str | list[str]]] | None = None,
+        default_materialization_details: str | None = None,
     ):
         super().__init__()
 
-        if kwargs:
-            optional_args = {
-                "materialization_details",
-                "default_materialization_details",
-            }
-            if not set(kwargs.keys()).issubset(optional_args):
-                raise TypeError(
-                    f"The given arguments {set(kwargs.keys()) - optional_args}"
-                    f" are not supported."
-                )
-            error_msg = f"The table store does not support {set(kwargs.keys())}."
+        if (
+            materialization_details is not None
+            or default_materialization_details is not None
+        ) and self._materialization_details_class is None:
+            error_msg = "The table store does not support materialization details."
             if strict_materialization_details:
                 raise TypeError(
                     f"{error_msg} To suppress this exception, "
@@ -290,6 +302,17 @@ class SQLTableStore(BaseTableStore):
             sa.Column("task_hash", sa.String(20)),
             sa.Column("in_transaction_schema", sa.Boolean()),
         )
+
+        if self._materialization_details_class is not None:
+            self.materialization_details = (
+                self._materialization_details_class.create_materialization_details_dict(
+                    materialization_details,
+                    self.strict_materialization_details,
+                    default_materialization_details,
+                    self.logger,
+                )
+            )
+            self.default_materialization_details = default_materialization_details
 
         self.logger.info(
             "Initialized SQL Table Store",
@@ -408,9 +431,14 @@ class SQLTableStore(BaseTableStore):
         return self._execute(query, conn)
 
     def check_materialization_details_supported(self, label: str | None) -> None:
-        from pydiverse.pipedag.backend.table.sql.dialects import IBMDB2TableStore
+        from pydiverse.pipedag.backend.table.sql.dialects import (
+            IBMDB2TableStore,
+            PostgresTableStore,
+        )
 
-        if label is not None and not isinstance(self, IBMDB2TableStore):
+        if label is not None and not isinstance(
+            self, (IBMDB2TableStore, PostgresTableStore)
+        ):
             error_msg = (
                 f"Materialization details are not supported"
                 f" for store {type(self).__name__}."

--- a/src/pydiverse/pipedag/materialize/details.py
+++ b/src/pydiverse/pipedag/materialize/details.py
@@ -43,11 +43,16 @@ class BaseMaterializationDetails(ABC):
     @classmethod
     def create_materialization_details_dict(
         cls: type[_T],
-        materialization_details_cfg: dict[str, dict[str | list[str]]],
+        materialization_details_cfg: dict[str, dict[str | list[str]]] | None,
         strict: bool,
         default_materialization_details: str | None,
         logger,
     ) -> dict[str, _T]:
+        materialization_details_cfg = (
+            materialization_details_cfg
+            if materialization_details_cfg is not None
+            else dict()
+        )
         materialization_details: dict[str, _T] = dict()
         materialization_details["__any__"] = (
             cls.from_dict(materialization_details_cfg["__any__"], strict, logger)
@@ -77,13 +82,18 @@ class BaseMaterializationDetails(ABC):
         cls: type[_T],
         d: dict[str, _T],
         label: str,
-        default_label: str,
+        default_label: str | None,
         attribute: str,
         strict: bool,
         logger,
     ):
-        if label is None:
-            label = default_label
+        label = (
+            label
+            if label is not None
+            else default_label
+            if default_label is not None
+            else "__any__"
+        )
         if label not in d:
             error_msg = f"{label} is an unknown materialization details label."
             if strict:

--- a/tests/test_sql_dialect/test_postgres.py
+++ b/tests/test_sql_dialect/test_postgres.py
@@ -41,7 +41,11 @@ def test_postgres_unlogged():
     @materialize(input_type=pd.DataFrame)
     def assert_relpersistence(df: pd.DataFrame):
         relpersistence = (
-            "u" if ConfigContext.get().store.table_store.unlogged_tables else "p"
+            "u"
+            if ConfigContext.get()
+            .store.table_store.materialization_details["__any__"]
+            .unlogged
+            else "p"
         )
         assert df["relpersistence"][0] == relpersistence
 


### PR DESCRIPTION
This PR builds on #122.
I moves the Postgres `unlogged` feature to the materialization details.
Also, it refactors some code around the table stores needed for materialization details to reduce code duplication.
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

# Checklist

- [x] Added a `docs/source/changelog.md` entry
