### PR TITLE
Fix no materialization details

### DIFF
--- a/pipedag.yaml
+++ b/pipedag.yaml
@@ -16,24 +16,6 @@ table_store_connections:
       url: "db2+ibm_db://db2inst1:password@localhost:50000/testdb"
       schema_prefix: "{instance_id}_"
       create_database_if_not_exists: false
-      strict_materialization_details: false
-      default_materialization_details: "no_compression"
-      materialization_details:
-        __any__:
-          compression: [ "COMPRESS YES ADAPTIVE" ]
-        no_compression:
-          compression: ""
-        value_compression:
-          compression: "VALUE COMPRESSION"
-        static_compression:
-          compression: "COMPRESS YES STATIC"
-        adaptive_value_compression:
-          compression: [ "COMPRESS YES ADAPTIVE", "VALUE COMPRESSION" ]
-        table_space:
-          table_space_data: "S1"
-          table_space_index: "S2"
-          table_space_long: "S3"
-
 
   duckdb:
     args:
@@ -119,6 +101,31 @@ instances:
       table_store_connection: ibm_db2
       args:
         avoid_drop_create_schema: true
+
+  ibm_db2_materialization_details:
+    instance_id: pd_ibm_db2_materialization_details
+    stage_commit_technique: READ_VIEWS
+    table_store:
+      table_store_connection: ibm_db2
+      args:
+        strict_materialization_details: false
+        default_materialization_details: "no_compression"
+        materialization_details:
+          __any__:
+            compression: [ "COMPRESS YES ADAPTIVE" ]
+          no_compression:
+            compression: ""
+          value_compression:
+            compression: "VALUE COMPRESSION"
+          static_compression:
+            compression: "COMPRESS YES STATIC"
+          adaptive_value_compression:
+            compression: [ "COMPRESS YES ADAPTIVE", "VALUE COMPRESSION" ]
+          table_space:
+            table_space_data: "S1"
+            table_space_index: "S2"
+            table_space_long: "S3"
+
 
   duckdb:
     instance_id: pd_duckdb

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/ibm_db2.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/ibm_db2.py
@@ -64,7 +64,9 @@ class IBMDB2MaterializationDetails(BaseMaterializationDetails):
             "compression",
             IBMDB2CompressionTypes(self.compression)
             if isinstance(self.compression, str)
-            else [IBMDB2CompressionTypes(c) for c in self.compression],
+            else [IBMDB2CompressionTypes(c) for c in self.compression]
+            if self.compression is not None
+            else None,
         )
 
     compression: IBMDB2CompressionTypes | list[IBMDB2CompressionTypes] | None = None

--- a/tests/fixtures/instances.py
+++ b/tests/fixtures/instances.py
@@ -24,6 +24,7 @@ INSTANCE_MARKS = {
     "mssql_pytsql": pytest.mark.mssql,
     "ibm_db2": pytest.mark.ibm_db2,
     "ibm_db2_avoid_schema": pytest.mark.ibm_db2,
+    "ibm_db2_materialization_details": pytest.mark.ibm_db2,
     "duckdb": pytest.mark.duckdb,
     # Local Table Cache Instances
     "local_table_cache": pytest.mark.postgres,
@@ -55,6 +56,7 @@ ALL_INSTANCES = (
     "mssql_pytsql",
     "ibm_db2",
     "ibm_db2_avoid_schema",
+    "ibm_db2_materialization_details",
     "duckdb",
     "local_table_cache",
 )

--- a/tests/test_cache/test_ignore_cache_function.py
+++ b/tests/test_cache/test_ignore_cache_function.py
@@ -258,7 +258,14 @@ def test_blob(mocker):
 
 
 # TODO: Determine exactly why this test only works with postgres
-@skip_instances("mssql", "mssql_pytsql", "ibm_db2", "ibm_db2_avoid_schema", "duckdb")
+@skip_instances(
+    "mssql",
+    "mssql_pytsql",
+    "ibm_db2",
+    "ibm_db2_avoid_schema",
+    "ibm_db2_materialization_details",
+    "duckdb",
+)
 def test_raw_sql(mocker):
     cache_value = 0
     raw_value = 0

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -10,7 +10,11 @@ from pydiverse.pipedag.backend.table.sql.dialects import (
 )
 
 # Parameterize all tests in this file with several instance_id configurations
-from tests.fixtures.instances import DATABASE_INSTANCES, with_instances
+from tests.fixtures.instances import (
+    DATABASE_INSTANCES,
+    skip_instances,
+    with_instances,
+)
 from tests.util import tasks_library as m
 
 pytestmark = [with_instances(DATABASE_INSTANCES)]
@@ -27,6 +31,8 @@ pytestmark = [with_instances(DATABASE_INSTANCES)]
         (m.simple_dataframe_uncompressed, None),
     ],
 )
+@with_instances(DATABASE_INSTANCES, "ibm_db2_materialization_details")
+@skip_instances("ibm_db2")
 def test_compression(task, stage_materialization_details):
     @materialize(input_type=sa.Table, lazy=False)
     def get_compression_attributes(table: sa.Table):

--- a/tests/test_sql_dialect/test_ibm_db2.py
+++ b/tests/test_sql_dialect/test_ibm_db2.py
@@ -15,7 +15,7 @@ from tests.util.tasks_library import (
 )
 
 
-@with_instances("ibm_db2", "ibm_db2_avoid_schema")
+@with_instances("ibm_db2", "ibm_db2_avoid_schema", "ibm_db2_materialization_details")
 def test_db2_nicknames():
     @materialize(input_type=sa.Table)
     def create_nicknames(table: sa.Table):
@@ -43,7 +43,7 @@ def test_db2_nicknames():
     assert f.run().successful
 
 
-@with_instances("ibm_db2", "ibm_db2_avoid_schema")
+@with_instances("ibm_db2_materialization_details")
 @pytest.mark.parametrize("task", [simple_dataframe, simple_lazy_table])
 def test_db2_table_spaces(task):
     @materialize()


### PR DESCRIPTION
This PR fixes a crash when providing DB2 with no materialization details. It also adds a `ibm_db2_materialization_details` instance and removes the materialization details from the `ibm_db2` instance.
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

# Checklist

- [ ] Added a `docs/source/changelog.md` entry
