### PR TITLE
Copy task inputs to protect against modifications before execution time

### DIFF
--- a/src/pydiverse/pipedag/core/task.py
+++ b/src/pydiverse/pipedag/core/task.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import inspect
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Callable
@@ -72,7 +73,9 @@ class UnboundTask:
             raise StageError("Can't call pipedag task outside of a stage.")
 
         # Construct Task
-        bound_args = self._signature.bind(*args, **kwargs)
+        Task.__deepcopy__ = lambda self, memo: self
+        bound_args = self._signature.bind(*copy.deepcopy(args), **copy.deepcopy(kwargs))
+        delattr(Task, "__deepcopy__")
         return self._bound_task_type(self, bound_args, ctx.flow, ctx.stage)
 
     def _call_original_function(self, *args, **kwargs):

--- a/tests/test_flows/test_mutable_task_inputs.py
+++ b/tests/test_flows/test_mutable_task_inputs.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from pydiverse.pipedag import Flow, Stage, Table, materialize
+from tests.fixtures.instances import (
+    DATABASE_INSTANCES,
+    ORCHESTRATION_INSTANCES,
+    with_instances,
+)
+
+
+@materialize(version="1.0")
+def inputs():
+    df_a = pd.DataFrame(
+        {
+            "a": [0, 1, 2, 4],
+            "b": [9, 8, 7, 6],
+        }
+    )
+
+    return Table(df_a, "dfA")
+
+
+@materialize(input_type=pd.DataFrame, version="1.0")
+def double_a(tables: dict[str, pd.DataFrame]):
+    a = tables["dfA"]
+    a["a"] = a["a"] * 2
+    return Table(a, "dfA2")
+
+
+@materialize(input_type=pd.DataFrame, version="1.0")
+def halfen_table(table: pd.DataFrame):
+    return table / 2
+
+
+def halfen_tables(tables: dict[str, Table]):
+    for table_name in tables:
+        tables[table_name] = halfen_table(tables[table_name])
+    return tables
+
+
+def get_flow():
+    with Flow() as flow:
+        with Stage("simple_flow_stage1"):
+            a = inputs()
+            tables: dict[str, Table] = {"dfA": a}
+            a2 = double_a(tables)
+            tables["dfA2"] = a2
+            halfen_tables(tables)
+
+    return flow
+
+
+@with_instances(DATABASE_INSTANCES, ORCHESTRATION_INSTANCES)
+def test_simple_flow():
+    flow = get_flow()
+    result = flow.run()
+    assert result.successful


### PR DESCRIPTION
Currently task inputs may me modified after the task has been declared. This leads to the unintuitive situation that a task may receive different arguments at runtime than at declaration time. In particular constructions like
```python
a = inputs()
tables: dict[str, Table] = {"dfA": a}
a2 = double_a(tables)
tables["dfA2"] = a2
halfen_tables(tables)
```
crash at flow runtime, because `double_a` at runtime depends on the last version of `tables` which contains `"dfA2"` already.

Note that a fix for this breaks `test_change_bound_argument`.  

Is the current behavior intended?

# Checklist

- [ ] Added a `docs/source/changelog.md` entry
