### PR TITLE
Make lazy task output tables which do not provide a query string cache invalid for subsequent reading tasks

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.10 (2024-XX-XX)
+- Fix bug where a `Task` that was declared lazy but provided a `Table` without a query string would always be cache valid.
+
 ## 0.6.9 (2024-01-24)
 - Update dependencies and remove some upper boundaries
 - Polars dependency moved to >= 0.18.12 due to incompatible interface change

--- a/src/pydiverse/pipedag/backend/table/base.py
+++ b/src/pydiverse/pipedag/backend/table/base.py
@@ -341,6 +341,13 @@ class BaseTableStore(TableHookResolver, Disposable):
         except TypeError:
             # This table type doesn't provide a query string
             # -> Fallback to default implementation
+            self.logger.warning(
+                f"The output table {table.name} using given by"
+                f" {repr(table.obj)} of the lazy task {task.name} does"
+                " not provide a query string. Lazy evaluation is not"
+                " possible. Assuming that the task is not cache valid."
+            )
+            TaskContext.get().is_cache_valid = False
             return self.store_table(table, task)
 
         # Store the table

--- a/src/pydiverse/pipedag/backend/table/base.py
+++ b/src/pydiverse/pipedag/backend/table/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from enum import Enum
@@ -337,18 +338,17 @@ class BaseTableStore(TableHookResolver, Disposable):
         try:
             hook = self.get_m_table_hook(type(table.obj))
             query_str = hook.lazy_query_str(self, table.obj)
-            query_hash = stable_hash("LAZY-TABLE", query_str)
         except TypeError:
-            # This table type doesn't provide a query string
-            # -> Fallback to default implementation
             self.logger.warning(
                 f"The output table {table.name} using given by"
                 f" {repr(table.obj)} of the lazy task {task.name} does"
                 " not provide a query string. Lazy evaluation is not"
                 " possible. Assuming that the task is not cache valid."
             )
-            TaskContext.get().is_cache_valid = False
-            return self.store_table(table, task)
+            # Assign random query string to ensure that task is not cache valid
+            query_str = uuid.uuid4().hex
+
+        query_hash = stable_hash("LAZY-TABLE", query_str)
 
         # Store the table
         try:

--- a/src/pydiverse/pipedag/backend/table/base.py
+++ b/src/pydiverse/pipedag/backend/table/base.py
@@ -340,10 +340,10 @@ class BaseTableStore(TableHookResolver, Disposable):
             query_str = hook.lazy_query_str(self, table.obj)
         except TypeError:
             self.logger.warning(
-                f"The output table {table.name} using given by"
-                f" {repr(table.obj)} of the lazy task {task.name} does"
+                f"The output table {table.name} given by a"
+                f" {repr(type(table.obj))} of the lazy task {task.name} does"
                 " not provide a query string. Lazy evaluation is not"
-                " possible. Assuming that the task is not cache valid."
+                " possible. Assuming that the table is not cache valid."
             )
             # Assign random query string to ensure that task is not cache valid
             query_str = uuid.uuid4().hex

--- a/tests/test_cache/test_basic_cache_invalidation.py
+++ b/tests/test_cache/test_basic_cache_invalidation.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pandas as pd
-import polars as pl
 import pytest
 
 from pydiverse.pipedag import Blob, ConfigContext, Flow, Stage, Table
@@ -14,6 +13,8 @@ from tests.fixtures.instances import ALL_INSTANCES, with_instances
 from tests.util import compile_sql, select_as
 from tests.util import tasks_library as m
 from tests.util.spy import spy_task
+
+pl = pytest.importorskip("polars")
 
 pytestmark = [with_instances(ALL_INSTANCES)]
 

--- a/tests/test_cache/test_basic_cache_invalidation.py
+++ b/tests/test_cache/test_basic_cache_invalidation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pandas as pd
+import polars as pl
 
 from pydiverse.pipedag import Blob, ConfigContext, Flow, Stage, Table
 from pydiverse.pipedag.context import StageLockContext
@@ -599,31 +600,69 @@ def test_ignore_task_version(mocker):
             child_spy.assert_called_once()
 
 
-def test_lazy_task_without_query_string():
-    value = 0
+def test_lazy_task_without_query_string(mocker):
+    value = None
 
-    @materialize(lazy=True)
+    @materialize(lazy=True, nout=5)
     def falsely_lazy_task():
-        return pd.DataFrame({"x": [value]})
-
-    @materialize(version="1.0", input_type=pd.DataFrame)
-    def take_first(table):
-        return table["x"][0]
+        return (
+            Table(pd.DataFrame({"x": [value]}), name="pd_table"),
+            Table(pl.DataFrame({"x": [value]}), name="pl_table"),
+            Table(pl.DataFrame({"x": [value]}).lazy(), name="pl_lazy_table"),
+            select_as(2, "y"),
+            3,
+        )
 
     def get_flow():
         with Flow() as flow:
             with Stage("stage_1"):
-                tbl = falsely_lazy_task()
-                res = take_first(tbl)
-        return flow, res
+                pd_tbl, pl_tbl, pl_lazy_tbl, select_tbl, constant = falsely_lazy_task()
+                res_pd = m.take_first(pd_tbl)
+                res_pl = m.take_first(pl_tbl)
+                res_pl_lazy = m.take_first(pl_lazy_tbl)
+                res_select = m.noop(select_tbl)
+                res_constant = m.noop(constant)
+        return flow, res_pd, res_pl, res_pl_lazy, res_select, res_constant
 
-    flow, res = get_flow()
+    value = 0
+    flow, res_pd, res_pl, res_pl_lazy, res_select, res_constant = get_flow()
     with StageLockContext():
         result = flow.run()
-        assert result.get(res) == 0
+        assert result.get(res_pd) == 0
+        assert result.get(res_pl) == 0
+        assert result.get(res_pl_lazy) == 0
 
     value = 1
-    flow, res = get_flow()
+    flow, res_pd, res_pl, res_pl_lazy, res_select, res_constant = get_flow()
+    res_pd_spy = spy_task(mocker, res_pd)
+    res_pl_spy = spy_task(mocker, res_pl)
+    res_pl_lazy_spy = spy_task(mocker, res_pl_lazy)
+    select_spy = spy_task(mocker, res_select)
+    constant_spy = spy_task(mocker, res_constant)
     with StageLockContext():
         result = flow.run()
-        assert result.get(res) == 1
+        assert result.get(res_pd) == 1
+        assert result.get(res_pl) == 1
+        assert result.get(res_pl_lazy) == 1
+        # res_pd is downstream of a pd.DataFrame from a lazy task,
+        # which should always be cache invalid. Hence, it should always be called.
+        res_pd_spy.assert_called_once()
+
+        # res_pd is downstream of a pl.DataFrame from a lazy task,
+        # which should always be cache invalid. Hence, it should always be called.
+        res_pl_spy.assert_called_once()
+
+        # res_pd is downstream of a pl.LazyFrame from a lazy task,
+        # which should always be cache invalid. Hence, it should always be called.
+        # To avoid cache-invalidating the LazyFrame, we should use AUTOVERSION.
+        res_pl_lazy_spy.assert_called_once()
+
+        # res_select is downstream of an SQL query `select_tbl` (which did not change)
+        # from a lazy task, hence select_tbl should be cache valid and the task
+        # producing res_select should not be called.
+        select_spy.assert_not_called()
+
+        # res_constant is downstream of the constant `constant` (which did not change)
+        # from a lazy task, hence res_constant should be cache valid and the task
+        # producing res_select should not be called.
+        constant_spy.assert_not_called()

--- a/tests/test_cache/test_basic_cache_invalidation.py
+++ b/tests/test_cache/test_basic_cache_invalidation.py
@@ -14,7 +14,10 @@ from tests.util import compile_sql, select_as
 from tests.util import tasks_library as m
 from tests.util.spy import spy_task
 
-pl = pytest.importorskip("polars")
+try:
+    import polars as pl
+except ImportError:
+    pl = None
 
 pytestmark = [with_instances(ALL_INSTANCES)]
 
@@ -603,7 +606,7 @@ def test_ignore_task_version(mocker):
 
 
 @pytest.mark.polars
-def test_lazy_task_without_query_string(mocker):
+def test_lazy_table_without_query_string(mocker):
     value = None
 
     @materialize(lazy=True, nout=5)

--- a/tests/test_cache/test_basic_cache_invalidation.py
+++ b/tests/test_cache/test_basic_cache_invalidation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 import polars as pl
+import pytest
 
 from pydiverse.pipedag import Blob, ConfigContext, Flow, Stage, Table
 from pydiverse.pipedag.context import StageLockContext
@@ -600,6 +601,7 @@ def test_ignore_task_version(mocker):
             child_spy.assert_called_once()
 
 
+@pytest.mark.polars
 def test_lazy_task_without_query_string(mocker):
     value = None
 

--- a/tests/util/tasks_library.py
+++ b/tests/util/tasks_library.py
@@ -61,6 +61,11 @@ def assert_blob_equal(x, y):
     assert x == y
 
 
+@materialize(version="1.0", input_type=pd.DataFrame)
+def take_first(table):
+    return table["x"][0]
+
+
 @materialize(version="1.0")
 def simple_dataframe():
     df = pd.DataFrame(


### PR DESCRIPTION
The cache validity of a lazy task cannot be judged when the tables output by the task do not provide query strings. This should result in the task being cache invalid which it currently does not. This task fixes this.

# Checklist

- [x] Added a `docs/source/changelog.md` entry
