### PR TITLE
Update link to table backends

### DIFF
--- a/src/pydiverse/pipedag/materialize/core.py
+++ b/src/pydiverse/pipedag/materialize/core.py
@@ -81,8 +81,7 @@ def materialize(
     :param input_type:
         The data type as which to retrieve table objects from the store.
         All tables passed to this task get loaded from the table store and converted
-        to this type. See
-        https://pydiversepipedag.readthedocs.io/en/latest/table_backends.html for
+        to this type. See :doc:`Table Backends </table_backends>` for
         more information.
     :param version:
         The version of this task.


### PR DESCRIPTION
fixes the link in the docstring for the sphinx docs :)

![docs](https://github.com/pydiverse/pydiverse.pipedag/assets/49781814/8a7b13d9-ea5a-459d-b8ff-31c380fc8eca)
