### PR TITLE
Add some unicode tests

### DIFF
--- a/src/pydiverse/pipedag/backend/table/cache/parquet.py
+++ b/src/pydiverse/pipedag/backend/table/cache/parquet.py
@@ -71,7 +71,7 @@ class ParquetTableCache(BaseTableCache):
             return False
 
         try:
-            metadata = json.loads(metadata_path.read_text())
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
             return metadata["cache_key"] == table.cache_key
         except (OSError, json.decoder.JSONDecodeError):
             return False

--- a/tests/test_flows/raw_sql_scripts/mssql/prep/more_tables.sql
+++ b/tests/test_flows/raw_sql_scripts/mssql/prep/more_tables.sql
@@ -28,4 +28,25 @@ INNER JOIN (
   ON apgs.entity = base.entity
 CREATE INDEX raw_start_date ON {{out_schema}}.raw01A (start_date DESC)
 CREATE INDEX raw_start_date_end_date ON {{out_schema}}.raw01A (end_date, start_date DESC)
-
+GO
+SELECT 'äöüßéç' as string_col INTO {{out_schema}}.special_chars
+GO
+CREATE TABLE {{out_schema}}.special_chars2 (
+  id TINYINT NOT NULL PRIMARY KEY,
+  string_col VARCHAR(60) NOT NULL
+)
+INSERT INTO {{out_schema}}.special_chars2 (id, string_col) VALUES
+(1, 'äöüßéç')
+GO
+-- check that both strings match and have length 7 with NOT NULL constraint
+CREATE TABLE {{out_schema}}.special_chars_join (
+  string_col VARCHAR(60) NOT NULL,
+  string_col2 VARCHAR(60) NOT NULL,
+  string_col3 VARCHAR(60) NOT NULL
+)
+INSERT INTO {{out_schema}}.special_chars_join
+SELECT a.string_col, b.string_col, c.string_col
+FROM {{out_schema}}.special_chars a
+FULL OUTER JOIN {{out_schema}}.special_chars2 b ON a.string_col = b.string_col
+FULL OUTER JOIN {{out_schema}}.special_chars2 c ON a.string_col = c.string_col
+    and len(a.string_col) = 6 and len(c.string_col) = 6

--- a/tests/test_flows/test_raw_sql_pipeline.py
+++ b/tests/test_flows/test_raw_sql_pipeline.py
@@ -92,6 +92,9 @@ def _run_and_check(flow, prep_stage):
         assert set(inspector.get_table_names(schema=schema)) == {
             "raw01A",
             "table01",
+            "special_chars",
+            "special_chars2",
+            "special_chars_join",
         }
 
         pk = inspector.get_pk_constraint("raw01A", schema=schema)
@@ -108,3 +111,8 @@ def _run_and_check(flow, prep_stage):
         assert indexes[0]["column_names"] == ["start_date"]
         assert indexes[1]["name"] == "raw_start_date_end_date"
         assert indexes[1]["column_names"] == ["end_date", "start_date"]
+
+        with config_ctx.store.table_store.engine.connect() as conn:
+            sql = f"SELECT string_col FROM [{schema}].[special_chars_join]"
+            str_val = conn.execute(sa.text(sql)).fetchone()[0]
+            assert str_val == "äöüßéç"

--- a/tests/test_flows/test_raw_sql_pipeline.py
+++ b/tests/test_flows/test_raw_sql_pipeline.py
@@ -29,7 +29,7 @@ def tsql(
 ):
     _ = depend  # only relevant for adding additional task dependency
     script_path = script_directory / name
-    sql = Path(script_path).read_text()
+    sql = Path(script_path).read_text(encoding="utf-8")
     sql = raw_sql_bind_schema(sql, "out_", out_stage, transaction=True)
     sql = raw_sql_bind_schema(sql, "in_", in_sql)
     sql = raw_sql_bind_schema(sql, "helper_", helper_sql)

--- a/tests/test_flows/test_sql_text_node.py
+++ b/tests/test_flows/test_sql_text_node.py
@@ -11,7 +11,7 @@ from tests.fixtures.instances import with_instances
 
 @materialize(input_type=sa.Table, lazy=True)
 def table_1(script_path: str):
-    sql = Path(script_path).read_text()
+    sql = Path(script_path).read_text(encoding="utf-8")
     return Table(sa.text(sql), name="table_1")
 
 
@@ -19,7 +19,7 @@ def table_1(script_path: str):
 def table_2(script_path: str, dependent_table: Table):
     sql = (
         Path(script_path)
-        .read_text()
+        .read_text(encoding="utf-8")
         .replace("{{dependent}}", str(dependent_table.original))
     )
     return Table(sa.text(sql), name="test_table2")

--- a/tests/test_raw_sql/util.py
+++ b/tests/test_raw_sql/util.py
@@ -21,7 +21,7 @@ def sql_script(
     stage = TaskContext.get().task.stage
 
     script_path = script_directory / name
-    sql = Path(script_path).read_text()
+    sql = Path(script_path).read_text(encoding="utf-8")
     sql = raw_sql_bind_schema(sql, "out_", stage, transaction=True)
     sql = raw_sql_bind_schema(sql, "in_", input_stage)
     return RawSql(sql)

--- a/tests/test_sql_dialect/test_ibm_db2.py
+++ b/tests/test_sql_dialect/test_ibm_db2.py
@@ -20,7 +20,7 @@ def test_db2_nicknames():
     @materialize(input_type=sa.Table)
     def create_nicknames(table: sa.Table):
         script_path = Path(__file__).parent / "scripts" / "simple_nicknames.sql"
-        simple_nicknames = Path(script_path).read_text()
+        simple_nicknames = Path(script_path).read_text(encoding="utf-8")
         simple_nicknames = simple_nicknames.replace(
             "{{out_schema}}", str(table.original.schema)
         )
@@ -49,7 +49,7 @@ def test_db2_table_spaces(task):
     @materialize()
     def create_table_spaces():
         script_path = Path(__file__).parent / "scripts" / "simple_table_spaces.sql"
-        simple_table_spaces = Path(script_path).read_text()
+        simple_table_spaces = Path(script_path).read_text(encoding="utf-8")
         return RawSql(simple_table_spaces, "create_table_spaces", separator="|")
 
     @materialize(input_type=sa.Table, lazy=False)

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pandas as pd
+import sqlalchemy as sa
+
+from pydiverse.pipedag import Flow, Stage, materialize
+from pydiverse.pipedag.context import StageLockContext
+
+# Parameterize all tests in this file with several instance_id configurations
+from tests.fixtures.instances import (
+    ALL_INSTANCES,
+    ORCHESTRATION_INSTANCES,
+    skip_instances,
+    with_instances,
+)
+from tests.util import tasks_library as m
+
+pytestmark = [with_instances(ALL_INSTANCES, ORCHESTRATION_INSTANCES)]
+
+
+def test_unicode():
+    @materialize(lazy=True)
+    def unicode():
+        return sa.text("SELECT 'äöüßéç' as a")
+
+    with Flow("flow") as f:
+        with Stage("stage"):
+            x = unicode()
+            x2 = m.noop(x)
+            x3 = m.noop_lazy(x2)
+            m.assert_table_equal(x, x2)
+            m.assert_table_equal(x, x3)
+
+    with StageLockContext():
+        result = f.run()
+        assert result.successful
+        assert result.get(x3, as_type=pd.DataFrame)["a"][0] == "äöüßéç"
+
+
+@skip_instances("mssql")
+def test_unicode_beyond_mssql():
+    @materialize(lazy=True)
+    def unicode():
+        return sa.text("SELECT 'λ' as a")
+
+    with Flow("flow") as f:
+        with Stage("stage"):
+            x = unicode()
+            x2 = m.noop(x)
+            x3 = m.noop_lazy(x2)
+            m.assert_table_equal(x, x2)
+            m.assert_table_equal(x, x3)
+
+    with StageLockContext():
+        result = f.run()
+        assert result.successful
+        assert result.get(x3, as_type=pd.DataFrame)["a"][0] == "λ"

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -37,7 +37,7 @@ def test_unicode():
         assert result.get(x3, as_type=pd.DataFrame)["a"][0] == "äöüßéç"
 
 
-@skip_instances("mssql")
+@skip_instances("mssql", "mssql_pytsql")
 def test_unicode_beyond_mssql():
     @materialize(lazy=True)
     def unicode():

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -14,18 +14,20 @@ from tests.fixtures.instances import (
     with_instances,
 )
 from tests.util import tasks_library as m
+from tests.util.tasks_library import simple_dataframe
 
 pytestmark = [with_instances(ALL_INSTANCES, ORCHESTRATION_INSTANCES)]
 
 
-def test_unicode():
-    @materialize(lazy=True)
-    def unicode():
-        return sa.text("SELECT 'äöüßéç' as a")
+def test_unicode(unicode_str="äöüßéç"):
+    @materialize(lazy=True, input_type=sa.Table)
+    def unicode(src):
+        return sa.select(sa.literal(unicode_str).label("a")).select_from(src).limit(1)
 
     with Flow("flow") as f:
         with Stage("stage"):
-            x = unicode()
+            dummy_source = simple_dataframe()
+            x = unicode(dummy_source)
             x2 = m.noop(x)
             x3 = m.noop_lazy(x2)
             m.assert_table_equal(x, x2)
@@ -34,24 +36,9 @@ def test_unicode():
     with StageLockContext():
         result = f.run()
         assert result.successful
-        assert result.get(x3, as_type=pd.DataFrame)["a"][0] == "äöüßéç"
+        assert result.get(x3, as_type=pd.DataFrame)["a"][0] == unicode_str
 
 
 @skip_instances("mssql", "mssql_pytsql")
 def test_unicode_beyond_mssql():
-    @materialize(lazy=True)
-    def unicode():
-        return sa.text("SELECT 'λ' as a")
-
-    with Flow("flow") as f:
-        with Stage("stage"):
-            x = unicode()
-            x2 = m.noop(x)
-            x3 = m.noop_lazy(x2)
-            m.assert_table_equal(x, x2)
-            m.assert_table_equal(x, x3)
-
-    with StageLockContext():
-        result = f.run()
-        assert result.successful
-        assert result.get(x3, as_type=pd.DataFrame)["a"][0] == "λ"
+    test_unicode("λ")


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

This pull request is supposed to test special character handling with database targets. It is not comprehensive but the first tests using more than ASCII. It already turned out that Microsoft SQL Server is not handling some unicode characters such as λ (U+03BB) well.

The reason that unicode was found as a potential problem source turned out to be a problem in user code. In case you happen to load SQL files into pipedag, beware that `Path(path).read_text()` does not correctly read UTF-8 files on some operating systems. Explicitly specifying the encoding parameter is highly recommended. (see https://github.com/pydiverse/pydiverse.pipedag/blob/main/tests/test_flows/test_raw_sql_pipeline.py#L32)

# Checklist

- [x] Added a `docs/source/changelog.md` entry
