### PR TITLE
Fix numeric to float

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,12 +161,12 @@ def lazy_task_2(input1: sa.Table, input2: sa.Table):
 
 @materialize(lazy=True, input_type=sa.Table)
 def lazy_task_3(input1: sa.Table):
-    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.name}")
+    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.original.name}")
 
 
 @materialize(lazy=True, input_type=sa.Table)
 def lazy_task_4(input1: sa.Table):
-    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.name}")
+    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.original.name}")
 
 
 @materialize(nout=2, version="1.0.0")

--- a/docs/package/README.md
+++ b/docs/package/README.md
@@ -52,12 +52,12 @@ def lazy_task_2(input1: sa.Table, input2: sa.Table):
 
 @materialize(lazy=True, input_type=sa.Table)
 def lazy_task_3(input1: sa.Table):
-    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.name}")
+    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.original.name}")
 
 
 @materialize(lazy=True, input_type=sa.Table)
 def lazy_task_4(input1: sa.Table):
-    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.name}")
+    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.original.name}")
 
 
 @materialize(nout=2, version="1.0.0")

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## 0.7.1 (2024-03-11)
+- Fix bug when Reading DECIMAL(precision, scale) columns to pandas task (precision was interpreted like for Float where 
+precision <= 24 leads to float32). Beware that ``isinstance(sa.Float(), sa.Numeric) == True``.
+
 ## 0.7.0 (2024-03-10)
 - Rework `TableReference` support:
   * Rename `TableReference` to `ExternalTableReference`

--- a/docs/source/database_testing.md
+++ b/docs/source/database_testing.md
@@ -39,12 +39,12 @@ def lazy_task_2(input1: sa.Table, input2: sa.Table):
 
 @materialize(lazy=True, input_type=sa.Table)
 def lazy_task_3(input1: sa.Table):
-    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.name}")
+    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.original.name}")
 
 
 @materialize(lazy=True, input_type=sa.Table)
 def lazy_task_4(input1: sa.Table):
-    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.name}")
+    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.original.name}")
 
 
 @materialize(nout=2, version="1.0.0")

--- a/example/run_pipeline.py
+++ b/example/run_pipeline.py
@@ -31,12 +31,12 @@ def lazy_task_2(input1: sa.Table, input2: sa.Table):
 
 @materialize(lazy=True, input_type=sa.Table)
 def lazy_task_3(input1: sa.Table):
-    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.name}")
+    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.original.name}")
 
 
 @materialize(lazy=True, input_type=sa.Table)
 def lazy_task_4(input1: sa.Table):
-    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.name}")
+    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.original.name}")
 
 
 @materialize(nout=2, version="1.0.0")

--- a/example_postgres/run_pipeline.py
+++ b/example_postgres/run_pipeline.py
@@ -28,12 +28,12 @@ def lazy_task_2(input1: sa.Table, input2: sa.Table):
 
 @materialize(lazy=True, input_type=sa.Table)
 def lazy_task_3(input1: sa.Table):
-    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.name}")
+    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.original.name}")
 
 
 @materialize(lazy=True, input_type=sa.Table)
 def lazy_task_4(input1: sa.Table):
-    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.name}")
+    return sa.text(f"SELECT * FROM {input1.original.schema}.{input1.original.name}")
 
 
 @materialize(nout=2, version="1.0.0")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydiverse-pipedag"
-version = "0.7.0"
+version = "0.7.1"
 description = "A pipeline orchestration library executing tasks within one python session. It takes care of SQL table (de)materialization, caching and cache invalidation. Blob storage is supported as well for example for storing model files."
 authors = [
   "QuantCo, Inc.",

--- a/src/pydiverse/pipedag/backend/table/util/dtype.py
+++ b/src/pydiverse/pipedag/backend/table/util/dtype.py
@@ -57,10 +57,15 @@ class DType(Enum):
             return DType.INT64
         if isinstance(type_, sa.Integer):
             return DType.INT32
-        if isinstance(type_, sa.Numeric):
+        if isinstance(type_, sa.Float):
             precision = type_.precision or 53
             if precision <= 24:
                 return DType.FLOAT32
+            return DType.FLOAT64
+        if isinstance(type_, sa.Numeric):
+            # Just to be safe, we always use FLOAT64 for fixpoint numbers.
+            # Databases are obsessed about fixpoint. However, in dataframes, it
+            # is more common to just work with double precision floating point.
             return DType.FLOAT64
         if isinstance(type_, sa.String):
             return DType.STRING

--- a/tests/test_table_hooks/test_dtype_sqlalchemy.py
+++ b/tests/test_table_hooks/test_dtype_sqlalchemy.py
@@ -14,6 +14,10 @@ def test_dtype_from_sqlalchemy():
     assert_conversion(sa.SmallInteger(), DType.INT16)
 
     assert_conversion(sa.Numeric(), DType.FLOAT64)
+    assert_conversion(sa.Numeric(13, 2), DType.FLOAT64)
+    assert_conversion(sa.Numeric(1, 0), DType.FLOAT64)
+    assert_conversion(sa.DECIMAL(13, 2), DType.FLOAT64)
+    assert_conversion(sa.DECIMAL(1, 0), DType.FLOAT64)
     assert_conversion(sa.Float(), DType.FLOAT64)
     assert_conversion(sa.Float(24), DType.FLOAT32)
     assert_conversion(sa.Float(53), DType.FLOAT64)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Bug fix which has nothing to do with the release yesterday. But a project figured out problems loading fixpoint columns (i.e. DECIMAL(15,2) in a pandas task). The precision parameter of sa.Numeric was handled identically to sa.Float. However for Float it is in bits and for Numeric it is in decimal places. Nevertheless `isinstance(sa.Float(), sa.Numeric) == True`. 

# Checklist

- [x] Added a `docs/source/changelog.md` entry
