### PR TITLE
Support nullable and non_nullable parameters in pipedag.Table() and refactor ddl/table-store/hook logic

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,6 +1,16 @@
 # Changelog
 
 ## 0.7.2 (2024-03-DD)
+- Significant refactoring of materialization is included. It splits creation of table from filling a table in many cases.
+    This may lead to unexpected changes in log output. For now, the `INSERT INTO SELECT` statement is only printed in 
+    shortened version, because the creation of the table already includes the same statement in full. In the future, this
+    might be made configurable, so your feedback is highly welcome.
+- pipedag.Table() now supports new parameters `nullable` and `non_nullable`. This allows specifying which columns are 
+    nullable both as a positive and negative list. If both are specified, they must mention each column in the table and
+    have no overlap. For most dialects, non-nullable statements are issued after creating the empty table. For dialects 
+    `mssql` and `ibm_db2`, both nullable and non-nullable column alterations are issued because constant literals create
+    non-nullable columns by default. If neither nullable nor non_nullable are specified, the default `CREATE TABLE as SELECT`
+    is kept unmodified except for primary key columns where some dialects require explicit `NOT NULL` statements.
 - Disable Kroki links by default. New setting disable_kroki=True allows to still default kroki_url to https://kroki.io.
     Function create_basic_pipedag_config() just has a kroki_url parameter which defaults to None.
 - Added max_query_print_length parameter to MSSqlTableStore to limit the length of the printed SQL queries.

--- a/src/pydiverse/pipedag/backend/table/sql/ddl.py
+++ b/src/pydiverse/pipedag/backend/table/sql/ddl.py
@@ -185,7 +185,6 @@ class CopyTable(DDLElement):
         to_name,
         to_schema: Schema,
         if_not_exists=False,
-        early_not_null: None | str | list[str] = None,
         suffix: str = "",
     ):
         self.from_name = from_name
@@ -193,7 +192,6 @@ class CopyTable(DDLElement):
         self.to_name = to_name
         self.to_schema = to_schema
         self.if_not_exists = if_not_exists
-        self.early_not_null = early_not_null
         self.suffix = suffix
 
 
@@ -840,14 +838,6 @@ def visit_copy_table(copy_table: CopyTable, compiler, **kw):
         copy_table.to_name,
         copy_table.to_schema,
         query,
-        early_not_null=copy_table.early_not_null,
-        source_tables=[
-            dict(
-                name=copy_table.from_name,
-                schema=copy_table.from_schema.get(),
-                shared_lock_allowed=True,
-            )
-        ],
         suffix=copy_table.suffix,
     )
     return compiler.process(create, **kw)

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/duckdb.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/duckdb.py
@@ -74,7 +74,7 @@ class PandasTableHook(PandasTableHook):
         dtypes: dict[str, DType],
     ):
         engine = store.engine
-        dtypes = {name: dtype.to_sql() for name, dtype in dtypes.items()}
+        dtypes = cls._get_dialect_dtypes(dtypes, table)
         if table.type_map:
             dtypes.update(table.type_map)
 
@@ -83,12 +83,9 @@ class PandasTableHook(PandasTableHook):
         )
 
         # Create empty table with correct schema
-        df[:0].to_sql(
-            table.name,
-            engine,
-            schema=schema.get(),
-            index=False,
-            dtype=dtypes,
+        cls._dialect_create_empty_table(store, df, table, schema, dtypes)
+        store.add_indexes_and_set_nullable(
+            table, schema, on_empty_table=True, table_cols=df.columns
         )
 
         # Copy dataframe directly to duckdb
@@ -100,6 +97,13 @@ class PandasTableHook(PandasTableHook):
         connection_uri = connection_uri.replace("duckdb:///", "", 1)
         with duckdb.connect(connection_uri) as conn:
             conn.execute(f"INSERT INTO {schema_name}.{table_name} SELECT * FROM df")
+
+        store.add_indexes_and_set_nullable(
+            table,
+            schema,
+            on_empty_table=False,
+            table_cols=df.columns,
+        )
 
 
 try:

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/duckdb.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/duckdb.py
@@ -57,6 +57,10 @@ class DuckDBTableStore(SQLTableStore):
         database_path = Path(database)
         database_path.parent.mkdir(parents=True, exist_ok=True)
 
+    def dialect_requests_empty_creation(self, table: Table, is_sql: bool) -> bool:
+        _ = table, is_sql
+        return False  # DuckDB is not good with stable type arithmetic
+
 
 @DuckDBTableStore.register_table(pd)
 class PandasTableHook(PandasTableHook):

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/ibm_db2.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/ibm_db2.py
@@ -143,7 +143,7 @@ class IBMDB2TableStore(SQLTableStore):
             nullable_cols = [
                 col for col in nullable_cols if col not in table.primary_key
             ]
-        return non_nullable_cols, nullable_cols
+        return nullable_cols, non_nullable_cols
 
     def add_indexes_and_set_nullable(
         self,

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/ibm_db2.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/ibm_db2.py
@@ -95,7 +95,7 @@ class IBMDB2TableStore(SQLTableStore):
         """
         stmt = LockTable(table.name if isinstance(table, Table) else table, schema)
         if conn is not None:
-            self.execute(stmt, conn=conn, transaction_already_open=True)
+            self.execute(stmt, conn=conn)
         return [stmt]
 
     def lock_source_table(
@@ -108,7 +108,7 @@ class IBMDB2TableStore(SQLTableStore):
             table.name if isinstance(table, Table) else table, schema
         )
         if conn is not None:
-            self.execute(stmt, conn=conn, transaction_already_open=True)
+            self.execute(stmt, conn=conn)
         return [stmt]
 
     def dialect_requests_empty_creation(self, table: Table, is_sql: bool) -> bool:
@@ -124,13 +124,13 @@ class IBMDB2TableStore(SQLTableStore):
                 or (table.primary_key is not None and len(table.primary_key) > 0)
             )
 
-    def get_non_nullable_cols(
+    def get_forced_nullability_columns(
         self, table: Table, table_cols: Iterable[str], report_nullable_cols=False
     ) -> tuple[list[str], list[str]]:
         # ibm_db2 dialect has literals as non-nullable types by default, so we also need
         # the list of nullable columns to fix
-        nullable_cols, non_nullable_cols = super().get_non_nullable_cols(
-            table, table_cols, report_nullable_cols=True
+        nullable_cols, non_nullable_cols = self._process_table_nullable_parameters(
+            table, table_cols
         )
         # add primery key columns to non_nullable_cols
         if table.primary_key:

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/mssql.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/mssql.py
@@ -237,7 +237,7 @@ class MSSqlTableStore(SQLTableStore):
             print_query_string = self.format_sql_string(sql_string)
             if len(print_query_string) >= self.max_query_print_length:
                 print_query_string = (
-                    print_query_string[: self.max_query_print_length] + " [...]"
+                    print_query_string[: self.max_query_print_length] + " [...]\n"
                 )
             self.logger.info("Executing sql", query=print_query_string)
         # ensure database connection is reset to original database

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/postgres.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/postgres.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import csv
 from dataclasses import dataclass
 from io import StringIO
+from typing import Any
 
 import pandas as pd
-import sqlalchemy as sa
 
 from pydiverse.pipedag.backend.table.sql.ddl import (
     ChangeTableLogged,
-    CreateTableAsSelect,
+    LockSourceTable,
+    LockTable,
     Schema,
 )
 from pydiverse.pipedag.backend.table.sql.hooks import (
@@ -66,6 +67,24 @@ class PostgresTableStore(SQLTableStore):
             self.logger,
         )
 
+    def lock_table(self, table: Table | str, schema: Schema | str, conn: Any):
+        """
+        For some dialects, it might be beneficial to lock a table before writing to it.
+        """
+        self.execute(
+            LockTable(table.name if isinstance(table, Table) else table, schema),
+            conn=conn,
+        )
+
+    def lock_source_table(self, table: Table | str, schema: Schema | str, conn: Any):
+        """
+        For some dialects, it might be beneficial to lock source tables before reading.
+        """
+        self.execute(
+            LockSourceTable(table.name if isinstance(table, Table) else table, schema),
+            conn=conn,
+        )
+
     def check_materialization_details_supported(self, label: str | None) -> None:
         _ = label
         return
@@ -85,33 +104,7 @@ class PostgresTableStore(SQLTableStore):
 
 @PostgresTableStore.register_table()
 class SQLAlchemyTableHook(SQLAlchemyTableHook):
-    @classmethod
-    def materialize(
-        cls,
-        store: PostgresTableStore,
-        table: Table[sa.sql.expression.TextClause | sa.Text],
-        stage_name,
-    ):
-        obj = table.obj
-        if isinstance(table.obj, (sa.Table, sa.sql.expression.Alias)):
-            obj = sa.select("*").select_from(table.obj)
-
-        store.check_materialization_details_supported(
-            resolve_materialization_details_label(table)
-        )
-
-        schema = store.get_schema(stage_name)
-        store.execute(
-            CreateTableAsSelect(
-                table.name,
-                schema,
-                obj,
-                unlogged=store.get_unlogged(
-                    resolve_materialization_details_label(table)
-                ),
-            )
-        )
-        store.add_indexes(table, schema, early_not_null_possible=True)
+    pass  # postges is our reference dialect
 
 
 @PostgresTableStore.register_table(pd)

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/postgres.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/postgres.py
@@ -130,12 +130,9 @@ class PandasTableHook(PandasTableHook):
             dtypes.update(table.type_map)
 
         # Create empty table
-        df[:0].to_sql(
-            table.name,
-            engine,
-            schema=schema.get(),
-            index=False,
-            dtype=dtypes,
+        cls._dialect_create_empty_table(store, df, table, schema, dtypes)
+        store.add_indexes_and_set_nullable(
+            table, schema, on_empty_table=True, table_cols=df.columns
         )
 
         if store.get_unlogged(resolve_materialization_details_label(table)):

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/postgres.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/postgres.py
@@ -67,23 +67,29 @@ class PostgresTableStore(SQLTableStore):
             self.logger,
         )
 
-    def lock_table(self, table: Table | str, schema: Schema | str, conn: Any):
+    def lock_table(
+        self, table: Table | str, schema: Schema | str, conn: Any = None
+    ) -> list:
         """
         For some dialects, it might be beneficial to lock a table before writing to it.
         """
-        self.execute(
-            LockTable(table.name if isinstance(table, Table) else table, schema),
-            conn=conn,
-        )
+        stmt = LockTable(table.name if isinstance(table, Table) else table, schema)
+        if conn is not None:
+            self.execute(stmt, conn=conn)
+        return [stmt]
 
-    def lock_source_table(self, table: Table | str, schema: Schema | str, conn: Any):
+    def lock_source_table(
+        self, table: Table | str, schema: Schema | str, conn: Any = None
+    ) -> list:
         """
         For some dialects, it might be beneficial to lock source tables before reading.
         """
-        self.execute(
-            LockSourceTable(table.name if isinstance(table, Table) else table, schema),
-            conn=conn,
+        stmt = LockSourceTable(
+            table.name if isinstance(table, Table) else table, schema
         )
+        if conn is not None:
+            self.execute(stmt, conn=conn)
+        return [stmt]
 
     def check_materialization_details_supported(self, label: str | None) -> None:
         _ = label

--- a/src/pydiverse/pipedag/backend/table/sql/hooks.py
+++ b/src/pydiverse/pipedag/backend/table/sql/hooks.py
@@ -111,7 +111,7 @@ class SQLAlchemyTableHook(TableHook[SQLTableStore]):
             ]
             store.execute(
                 statements,
-                heavy_shorten_print=True,
+                truncate_printed_select=True,
             )
             store.add_indexes_and_set_nullable(table, schema, on_empty_table=False)
         else:

--- a/src/pydiverse/pipedag/backend/table/sql/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql/sql.py
@@ -983,9 +983,9 @@ class SQLTableStore(BaseTableStore):
             raise CacheError(msg)
 
         from_tbl = sa.Table(from_name, sa.MetaData(), schema=from_schema.get())
-        query = sa.select("*").select_from(from_tbl)
         dest_tbl = table.copy_without_obj()
-        dest_tbl.obj = query
+        dest_tbl.obj = from_tbl
+        dest_tbl.shared_lock_allowed = True
 
         # Copy table via executing a select statement with respective hook
         hook = self.get_m_table_hook(type(dest_tbl.obj))

--- a/src/pydiverse/pipedag/backend/table/sql/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql/sql.py
@@ -498,14 +498,10 @@ class SQLTableStore(BaseTableStore):
         rows: int,
     ) -> sa.sql.expression.Select:
         if isinstance(query, sa.sql.expression.TextClause):
-            # This is quite a hack. We look for the first SELECT and then use
-            # sqlalchemy to put the limit/top clause in the correct position.
-            # Furthermore, we search for a LIMIT n or TOP n clause to replace it.
-            query_str = str(query)
             return (
                 sa.select(sa.text("*"))
                 .limit(rows)
-                .select_from(sa.text("(" + query_str + ") AS A"))
+                .select_from(sa.text("(" + str(query) + ") AS A"))
             )
         else:
             return sa.select(sa.text("*")).limit(rows).select_from(query.alias("A"))

--- a/src/pydiverse/pipedag/materialize/container.py
+++ b/src/pydiverse/pipedag/materialize/container.py
@@ -88,6 +88,18 @@ class Table(Generic[T]):
                 for col in index:
                     if not isinstance(col, str):
                         raise indexes_type_error
+        for arg, name in [
+            (self.nullable, "nullable"),
+            (self.non_nullable, "non_nullable"),
+        ]:
+            type_error = TypeError(
+                f"Table argument '{name}' must be of type list[str]."
+            )
+            if arg is not None:
+                if not isinstance(arg, Iterable) or isinstance(arg, str):
+                    raise type_error
+                if not all(isinstance(x, str) for x in arg):
+                    raise type_error
 
         from pydiverse.pipedag.backend.table.sql import ExternalTableReference
 

--- a/src/pydiverse/pipedag/materialize/container.py
+++ b/src/pydiverse/pipedag/materialize/container.py
@@ -37,6 +37,10 @@ class Table(Generic[T]):
     :param type_map: Optional map of column names to types. Depending on the table
         store this will allow you to control the datatype as which the specified
         columns get materialized.
+    :param nullable: List of columns that should be nullable. If nullable is not None,
+        all other columns will be non-nullable.
+    :param non_nullable: List of columns that should be non-nullable. If non_nullable
+        is not None, all other columns will be nullable.
     :param materialization_details: The label of the materialization_details to be used.
         Overwrites the label given by the stage.
 
@@ -52,6 +56,8 @@ class Table(Generic[T]):
         primary_key: str | list[str] | None = None,
         indexes: list[list[str]] | None = None,
         type_map: dict[str, Any] | None = None,
+        nullable: list[str] | None = None,
+        non_nullable: list[str] | None = None,
         materialization_details: str | None = None,
     ):
         self._name = None
@@ -64,6 +70,8 @@ class Table(Generic[T]):
         self.primary_key = primary_key
         self.indexes = indexes
         self.type_map = type_map
+        self.nullable = nullable
+        self.non_nullable = non_nullable
         self.materialization_details = materialization_details
 
         # Check that indexes is of type list[list[str]]

--- a/tests/test_cache/test_basic_cache_invalidation.py
+++ b/tests/test_cache/test_basic_cache_invalidation.py
@@ -582,7 +582,7 @@ def test_change_version_table(mocker):
             cpy_spy.assert_called_once()
 
 
-@pytest.mark.parametrize("n", [1, 2, 100])
+@pytest.mark.parametrize("n", [1, 2, 15])
 def test_partial_stage_cache_valid(mocker, n):
     cache_value = 0
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

The initial idea of this PR is to add a nullable and non_nullable parameter to pipedag.Table(). It should allow specifying nullability both positive and negative. For most dialects it is beneficial to create an empty table, then set nullability, and finally fill the table.

This PR turned into a somewhat bigger refactoring. DB2 had some create empty table and then fill it logic in DDL code, but if it is not a single dialect, I prefer such complex control in the hook and table store code. Also the generic/specific split of how derived classes can customize the generic algorithm was redesigned.

# Checklist

- [x] Added a `docs/source/changelog.md` entry
