### PR TITLE
Add option to `Flow.run` to force execution of all tasks

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -6,7 +6,9 @@
 - Added max_query_print_length parameter to MSSqlTableStore to limit the length of the printed SQL queries.
     Default is max_query_print_length=500000 characters.
 - Fix bug when creating a table with the same name as a `Table` given by `ExternalTableReference` in the same stage.
-- Add support for `force_task_execution` in `Flow.run` to force execution of tasks even if they are cache valid.
+- Add support for `force_task_execution` in `Flow.run` to force execution of tasks even if they are cache valid. This implies `ignore_cache_function=True`.
+- Make `ignore_cache_function=True` prevent cache function calls.
+- Materialize lazy tasks, when they are executed without stage context.
 
 ## 0.7.1 (2024-03-11)
 - Fix bug when Reading DECIMAL(precision, scale) columns to pandas task (precision was interpreted like for Float where 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -5,8 +5,8 @@
     Function create_basic_pipedag_config() just has a kroki_url parameter which defaults to None.
 - Added max_query_print_length parameter to MSSqlTableStore to limit the length of the printed SQL queries.
     Default is max_query_print_length=500000 characters.
-- Fix bug when creating a table with the same name as a `Table` given by `ExternalTableReference` in the same stage  
-
+- Fix bug when creating a table with the same name as a `Table` given by `ExternalTableReference` in the same stage.
+- Add support for `force_task_execution` in `Flow.run` to force execution of tasks even if they are cache valid.
 
 ## 0.7.1 (2024-03-11)
 - Fix bug when Reading DECIMAL(precision, scale) columns to pandas task (precision was interpreted like for Float where 

--- a/src/pydiverse/pipedag/core/flow.py
+++ b/src/pydiverse/pipedag/core/flow.py
@@ -241,7 +241,8 @@ class Flow:
             the cache validity of a task.
         :param force_task_execution:
             Force the execution of all tasks in the executed (sub-)flow,
-            even if they are cache valid.
+            even if they are cache valid. `force_task_execution=True` implies
+            `ignore_cache_function=True`.
         :param kwargs:
             Other keyword arguments that get passed on directly to the
             ``run()`` method of the orchestration engine. Consequently, these
@@ -285,7 +286,7 @@ class Flow:
         # Evolve config using the arguments passed to flow.run
         config = config.evolve(
             fail_fast=(fail_fast if fail_fast is not None else config.fail_fast),
-            ignore_cache_function=ignore_cache_function,
+            ignore_cache_function=ignore_cache_function or force_task_execution,
             force_task_execution=(
                 # If subflow consists of a subset of tasks (-> not a subset of stages)
                 # then we want to skip cache validity checking to ensure the tasks

--- a/src/pydiverse/pipedag/core/flow.py
+++ b/src/pydiverse/pipedag/core/flow.py
@@ -210,6 +210,7 @@ class Flow:
         orchestration_engine: OrchestrationEngine = None,
         fail_fast: bool | None = None,
         ignore_cache_function: bool = False,
+        force_task_execution: bool = False,
         **kwargs,
     ) -> Result:
         """Execute the flow.
@@ -238,6 +239,9 @@ class Flow:
         :param ignore_cache_function:
             When set to True, the task's cache function gets ignored when determining
             the cache validity of a task.
+        :param force_task_execution:
+            Force the execution of all tasks in the executed (sub-)flow,
+            even if they are cache valid.
         :param kwargs:
             Other keyword arguments that get passed on directly to the
             ``run()`` method of the orchestration engine. Consequently, these
@@ -287,6 +291,7 @@ class Flow:
                 # then we want to skip cache validity checking to ensure the tasks
                 # always get executed.
                 subflow.is_tasks_subflow
+                or force_task_execution
             ),
         )
 

--- a/src/pydiverse/pipedag/materialize/core.py
+++ b/src/pydiverse/pipedag/materialize/core.py
@@ -500,7 +500,7 @@ class MaterializationWrapper:
         input_hash = stable_hash("INPUT", input_json)
 
         cache_fn_hash = ""
-        if task.cache is not None:
+        if task.cache is not None and not config_context.ignore_cache_function:
             cache_fn_output = store.json_encode(task.cache(*args, **kwargs))
             cache_fn_hash = stable_hash("CACHE_FN", cache_fn_output)
 
@@ -559,7 +559,7 @@ class MaterializationWrapper:
 
                     try:
                         _, cache_metadata = store.retrieve_cached_output(
-                            task, input_hash, cache_fn_hash
+                            task, input_hash, ""
                         )
                         cache_fn_hash = cache_metadata.cache_fn_hash
                     except CacheError as e:

--- a/tests/test_run_subflow.py
+++ b/tests/test_run_subflow.py
@@ -84,6 +84,20 @@ def test_run_specific_task(mocker):
     s2_spy.assert_not_called()
     assert_task_state(res.task_states, l1.name, FinalTaskState.COMPLETED)
 
+    res = f.run(force_task_execution=True)
+    x1_spy.assert_called_once()
+    x2_spy.assert_called_once()
+    l1_spy.assert_called_once()
+    s1_spy.assert_called_once()
+    y1_spy.assert_called_once()
+    y2_spy.assert_called_once()
+    s2_spy.assert_called_once()
+    assert_task_state(res.task_states, x1.name, FinalTaskState.COMPLETED)
+    assert_task_state(res.task_states, x2.name, FinalTaskState.COMPLETED)
+    assert_task_state(res.task_states, l1.name, FinalTaskState.COMPLETED)
+    assert_task_state(res.task_states, y1.name, FinalTaskState.COMPLETED)
+    assert_task_state(res.task_states, y2.name, FinalTaskState.COMPLETED)
+
 
 def test_run_specific_task_ambiguous_input(mocker):
     with Flow() as f:

--- a/tests/test_run_subflow.py
+++ b/tests/test_run_subflow.py
@@ -1,18 +1,29 @@
 from __future__ import annotations
 
-from pydiverse.pipedag import Flow, Stage
+from pydiverse.pipedag import Flow, Stage, Task
+from pydiverse.pipedag.context import FinalTaskState
 from tests.fixtures.instances import with_instances
 from tests.util import tasks_library as m
 from tests.util.spy import spy_task
 
 
 def test_run_specific_task(mocker):
+    def assert_task_state(
+        task_states: dict[Task, FinalTaskState],
+        task_name: str,
+        expected_state: FinalTaskState,
+    ):
+        tasks = [t for t in task_states if t.name == task_name]
+        assert len(tasks) > 0
+        assert all(task_states[t] == expected_state for t in tasks)
+
     # We need to assign unique names to these stages, because we can't reuse the
     # same stage lock context between different runs.
     with Flow() as f:
         with Stage("subflow_t1") as s1:
             x1 = m.one()
             x2 = m.two()
+            l1 = m.one_sql_lazy()
 
         with Stage("subflow_t2") as s2:
             y1 = m.create_tuple(x1, x2)
@@ -22,6 +33,7 @@ def test_run_specific_task(mocker):
 
     x1_spy = spy_task(mocker, x1)
     x2_spy = spy_task(mocker, x2)
+    l1_spy = spy_task(mocker, l1)
     s1_spy = spy_task(mocker, s1.commit_task)
     y1_spy = spy_task(mocker, y1)
     y2_spy = spy_task(mocker, y2)
@@ -29,31 +41,48 @@ def test_run_specific_task(mocker):
 
     # Run single task separately
 
-    f.run(x1)
+    res = f.run(x1)
     x1_spy.assert_called_once()
     x2_spy.assert_not_called()
+    l1_spy.assert_not_called()
     s1_spy.assert_not_called()
     y1_spy.assert_not_called()
     y2_spy.assert_not_called()
     s2_spy.assert_not_called()
+    assert_task_state(res.task_states, x1.name, FinalTaskState.COMPLETED)
 
-    f.run(y1)
+    res = f.run(y1)
     x1_spy.assert_not_called()
     x2_spy.assert_not_called()
+    l1_spy.assert_not_called()
     s1_spy.assert_not_called()
     y1_spy.assert_called_once()
     y2_spy.assert_not_called()
     s2_spy.assert_not_called()
+    assert_task_state(res.task_states, y1.name, FinalTaskState.COMPLETED)
 
     # Run multiple tasks at once
 
-    f.run(x2, y2)
+    res = f.run(x2, y2)
     x1_spy.assert_not_called()
     x2_spy.assert_called_once()
+    l1_spy.assert_not_called()
     s1_spy.assert_not_called()
     y1_spy.assert_not_called()
     y2_spy.assert_called_once()
     s2_spy.assert_not_called()
+    assert_task_state(res.task_states, x2.name, FinalTaskState.COMPLETED)
+    assert_task_state(res.task_states, y2.name, FinalTaskState.COMPLETED)
+
+    res = f.run(l1)
+    x1_spy.assert_not_called()
+    x2_spy.assert_not_called()
+    l1_spy.assert_called_once()
+    s1_spy.assert_not_called()
+    y1_spy.assert_not_called()
+    y2_spy.assert_not_called()
+    s2_spy.assert_not_called()
+    assert_task_state(res.task_states, l1.name, FinalTaskState.COMPLETED)
 
 
 def test_run_specific_task_ambiguous_input(mocker):

--- a/tests/util/tasks_library.py
+++ b/tests/util/tasks_library.py
@@ -5,6 +5,7 @@ import sqlalchemy as sa
 
 from pydiverse.pipedag import Blob, RawSql, Table, materialize
 from pydiverse.pipedag.debug import materialize_table
+from tests.util import select_as
 
 try:
     import polars as pl
@@ -50,6 +51,11 @@ def create_tuple(x, y):
 @materialize(version="1.0")
 def one():
     return 1
+
+
+@materialize(lazy=True)
+def one_sql_lazy():
+    return select_as(1, "x")
 
 
 @materialize(version="1.0")


### PR DESCRIPTION

Fixes #165 

Further changes:
- [x] Make `ignore_cache_function=True` prevent cache function calls
- [x] Make the new `force_task_execution=True` option in `flow.run()` imply `ignore_cache_function=True`
- [x] Materialize lazy tasks when `config_context._force_task_execution=True`.

# Checklist

- [x] Added a `docs/source/changelog.md` entry
