### PR TITLE
Emergency Release 0.7.2: Implemented config for max_copy_operations, pool_size, pool_timeout.

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,12 +1,16 @@
 # Changelog
 
-## 0.7.2 (2024-03-DD)
+## 0.7.2 (2024-03-25)
 - Disable Kroki links by default. New setting disable_kroki=True allows to still default kroki_url to https://kroki.io.
     Function create_basic_pipedag_config() just has a kroki_url parameter which defaults to None.
 - Added max_query_print_length parameter to MSSqlTableStore to limit the length of the printed SQL queries.
     Default is max_query_print_length=500000 characters.
 - Fix bug when creating a table with the same name as a `Table` given by `ExternalTableReference` in the same stage  
-
+- New config options for `SQLTableStore`:
+  * `max_concurrent_copy_operations` to limit the number of concurrent copy operations when copying tables between schemas.
+  * `sqlalchemy_pool_size` and `sqlalchemy_pool_timeout` to configure the pool size and timeout for the SQLAlchemy connection pool.
+  * The defaults fix a bug by setting sqlalchemy options to not time out when the first cache invalid task in a stage triggers
+    copying of cache valid tables between schemas and copying takes longer than 30s.
 
 ## 0.7.1 (2024-03-11)
 - Fix bug when Reading DECIMAL(precision, scale) columns to pandas task (precision was interpreted like for Float where 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydiverse-pipedag"
-version = "0.7.1"
+version = "0.7.2"
 description = "A pipeline orchestration library executing tasks within one python session. It takes care of SQL table (de)materialization, caching and cache invalidation. Blob storage is supported as well for example for storing model files."
 authors = [
   "QuantCo, Inc.",

--- a/src/pydiverse/pipedag/context/run_context.py
+++ b/src/pydiverse/pipedag/context/run_context.py
@@ -101,7 +101,10 @@ class RunContextServer(IPCServer):
         self.task_memo: defaultdict[Any, Any] = defaultdict(lambda: MemoState.NONE)
 
         # DEFERRED TABLE STORE OPERATIONS
-        self.deferred_thread_pool = ThreadPoolExecutor()
+        max_workers = 5
+        if hasattr(config_ctx.store.table_store, "max_concurrent_copy_operations"):
+            max_workers = config_ctx.store.table_store.max_concurrent_copy_operations
+        self.deferred_thread_pool = ThreadPoolExecutor(max_workers=max_workers)
         self.deferred_ts_ops: dict[int, list[DeferredTableStoreOp]] = {}
         self.deferred_ts_ops_futures: dict[int, list[Future]] = {}
         self.changed_stages: set[int] = set()


### PR DESCRIPTION
SQLTableStore, now supports parameters max_concurrent_copy_operations, sqlalchemy_pool_size, sqlalchemy_pool_timeout.

We encountered the situation that the pipeline aborted because a `sa.inspect()` call timed out because the full sqlalchemy connection pool was occupied copying tables between schemas.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

# Checklist

- [x] Added a `docs/source/changelog.md` entry
