### PR TITLE
Move primary key generation for mssql backend after completely filling a table.

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.9.1 (2024-XX-XX)
+## 0.9.1 (2024-04-26)
 - Support Snowflake as a backend for `SQLTableStore`.
+- For mssql backend, moved primary key adding after filling complete table.
 - Make polars dematerialization robust against missing connectorx. Fall back to pandas if connectorx is not available.
 - Fix some bugs with pandas < 2 and sqlalchemy < 2 compatibility as well as pyarrow handling.
 - Use pd.StringDtype("pyarrow") instead of pd.ArrowDtype(pa.string()) for dtype "string[pyarrow]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydiverse-pipedag"
-version = "0.9.0"
+version = "0.9.1"
 description = "A pipeline orchestration library executing tasks within one python session. It takes care of SQL table (de)materialization, caching and cache invalidation. Blob storage is supported as well for example for storing model files."
 authors = [
   "QuantCo, Inc.",

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/mssql.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/mssql.py
@@ -9,7 +9,6 @@ import sqlalchemy as sa
 import sqlalchemy.dialects.mssql
 
 from pydiverse.pipedag.backend.table.sql.ddl import (
-    AddIndex,
     ChangeColumnTypes,
     CreateAlias,
     _mssql_update_definition,
@@ -77,15 +76,6 @@ class MSSqlTableStore(SQLTableStore):
 
     def _init_database(self):
         self._init_database_with_database("master", {"isolation_level": "AUTOCOMMIT"})
-
-    def add_index(
-        self,
-        table_name: str,
-        schema: Schema,
-        index_columns: list[str],
-        name: str | None = None,
-    ):
-        self.execute(AddIndex(table_name, schema, index_columns, name))
 
     def dialect_requests_empty_creation(self, table: Table, is_sql: bool) -> bool:
         _ = is_sql

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/mssql.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/mssql.py
@@ -93,6 +93,7 @@ class MSSqlTableStore(SQLTableStore):
             table.nullable is not None
             or table.non_nullable is not None
             or (table.primary_key is not None and len(table.primary_key) > 0)
+            or (table.indexes is not None and len(table.indexes) > 0)
         )
 
     def get_forced_nullability_columns(


### PR DESCRIPTION
For mssql backend, moved string type changes for index columns after creation of empty table and before filling it. We were not sure at first which one would be faster.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

# Checklist

- [x] Added a `docs/source/changelog.md` entry
- [x] Added/updated documentation in `docs/source/`
- [x] Added/updated examples in `docs/source/examples.md`
