### PR TITLE
fix(): add previous_hook_replace argument for register_table

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## 0.9.3 ()
+## 0.9.3 (2024-06-11)
 - Added `upload_table()` and `download_table()` functions to the PandasTableHook to allow for easy 
     customization of up and download behavior of pandas and polars tables from/to the table store.
-- More robust way of looking up hooks independent of import order. In case no hook is found, the search continues with
-    the base class. This allows registering hooks for example with SQLTableStore after PostgresTableStore was declared.
+- More robust way of looking up hooks independent of import order. Subclasses of table stores don't 
+    copy registered hooks in the moment of declaration. When registering a hook it is possible now, to 
+    specify the hooks that are replaced by a new registration.
 
 ## 0.9.2 (2024-05-07)
 - @input_stage_versions decorator allows specifying tasks which compare tables within the current stage transaction 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -3,6 +3,8 @@
 ## 0.9.3 ()
 - Added `upload_table()` and `download_table()` functions to the PandasTableHook to allow for easy 
     customization of up and download behavior of pandas and polars tables from/to the table store.
+- More robust way of looking up hooks independent of import order. In case no hook is found, the search continues with
+    the base class. This allows registering hooks for example with SQLTableStore after PostgresTableStore was declared.
 
 ## 0.9.2 (2024-05-07)
 - @input_stage_versions decorator allows specifying tasks which compare tables within the current stage transaction 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydiverse-pipedag"
-version = "0.9.2"
+version = "0.9.3"
 description = "A pipeline orchestration library executing tasks within one python session. It takes care of SQL table (de)materialization, caching and cache invalidation. Blob storage is supported as well for example for storing model files."
 authors = [
   "QuantCo, Inc.",

--- a/src/pydiverse/pipedag/backend/lock/database.py
+++ b/src/pydiverse/pipedag/backend/lock/database.py
@@ -17,6 +17,8 @@ from pydiverse.pipedag.backend.table.sql.ddl import (
 from pydiverse.pipedag.errors import LockError
 from pydiverse.pipedag.materialize.container import Schema
 
+DISABLE_DIALECT_REGISTRATION = "__DISABLE_DIALECT_REGISTRATION"
+
 
 class DatabaseLockManager(BaseLockManager):
     """Lock manager based on database locking mechanisms
@@ -117,11 +119,13 @@ class DatabaseLockManager(BaseLockManager):
                 f"attribute. But {cls.__name__}._dialect_name is None."
             )
 
-        if dialect_name in DatabaseLockManager.__registered_dialects:
-            warnings.warn(
-                f"Already registered a DatabaseLockManager for dialect {dialect_name}"
-            )
-        DatabaseLockManager.__registered_dialects[dialect_name] = cls
+        if dialect_name != DISABLE_DIALECT_REGISTRATION:
+            if dialect_name in DatabaseLockManager.__registered_dialects:
+                warnings.warn(
+                    f"Already registered a DatabaseLockManager for dialect "
+                    f"{dialect_name}"
+                )
+            DatabaseLockManager.__registered_dialects[dialect_name] = cls
 
     def prepare(self):
         pass

--- a/src/pydiverse/pipedag/backend/table/base.py
+++ b/src/pydiverse/pipedag/backend/table/base.py
@@ -41,7 +41,7 @@ class TableHookResolver:
     def register_table(
         cls,
         *requirements: Any,
-        previous_hook_replace: list[type[TableHook]] | None = None,
+        replace_hooks: list[type[TableHook]] | None = None,
     ):
         """Decorator to register a `TableHook`
 
@@ -64,7 +64,7 @@ class TableHookResolver:
 
         :param requirements: The requirements which must be satisfied to register
             the decorated class.
-        :param previous_hook_replace: Takes the name of a TableHook class
+        :param replace_hooks: Takes the name of a TableHook class
         (e.g. PandasTableHook). If a name is provided the TableHook class
         is replaced by the newly registered hook.
         If None the new hook is just added to the list of available hooks.
@@ -90,8 +90,8 @@ class TableHookResolver:
                 )(hook_cls)
 
             # Register the hook
-            if previous_hook_replace:
-                # we ignore previous_hook_repacements if they are not found because
+            if replace_hooks:
+                # we ignore replace_hooks if they are not found because
                 # they might be registered in base class which has lower priority by
                 # design
                 # (attention: replace cls._registered_table_hooks since list instance
@@ -99,7 +99,7 @@ class TableHookResolver:
                 cls._registered_table_hooks = [
                     hook
                     for hook in cls._registered_table_hooks
-                    if hook not in previous_hook_replace
+                    if hook not in replace_hooks
                 ]
             cls._registered_table_hooks = cls._registered_table_hooks + [hook_cls]
             cls._m_hook_cache = {}

--- a/src/pydiverse/pipedag/backend/table/base.py
+++ b/src/pydiverse/pipedag/backend/table/base.py
@@ -60,8 +60,9 @@ class TableHookResolver:
 
         :param requirements: The requirements which must be satisfied to register
             the decorated class.
-        :param previous_hook_replace: Takes the name of a TableHook class (e.g. PandasTableHook).
-        If a name is provided the TableHook class is replaced by the newly registered hook.
+        :param previous_hook_replace: Takes the name of a TableHook class
+        (e.g. PandasTableHook). If a name is provided the TableHook class
+        is replaced by the newly registered hook.
         If None the new hook is just added to the list of available hooks.
         """
         if previous_hook_replace:

--- a/src/pydiverse/pipedag/backend/table/base.py
+++ b/src/pydiverse/pipedag/backend/table/base.py
@@ -93,10 +93,16 @@ class TableHookResolver:
 
         :param requirements: The requirements which must be satisfied to register
             the decorated class.
-        :param replace_hooks: Takes the name of a TableHook class
-        (e.g. PandasTableHook). If a name is provided the TableHook class
-        is replaced by the newly registered hook.
-        If None the new hook is just added to the list of available hooks.
+        :param replace_hooks: Takes a list of TableHook classes (e.g. PandasTableHook)
+            that should be replaced by the decorated class.
+            If None, the new hook is just added to the list of available hooks.
+
+            Details: specifying replace_hooks helps also implicitly because the
+            mentioned hooks must have been imported/registered before. If they were
+            registered on a base class of the hook resolver (i.e. table store) of this
+            call, they will be ignored but hooks registered on subclasses take
+            precedence anyway. Please make sure not provide replace hooks registered to
+            subclasses of this call's hook resolver. This will fail.
         """
 
         def decorator(hook_cls):

--- a/src/pydiverse/pipedag/backend/table/sql/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql/sql.py
@@ -46,6 +46,8 @@ from pydiverse.pipedag.materialize.metadata import (
 )
 from pydiverse.pipedag.util.hashing import stable_hash
 
+DISABLE_DIALECT_REGISTRATION = "__DISABLE_DIALECT_REGISTRATION"
+
 
 class SQLTableStore(BaseTableStore):
     """Table store that materializes tables to a SQL database
@@ -332,11 +334,12 @@ class SQLTableStore(BaseTableStore):
                 f" But {cls.__name__}._dialect_name is None."
             )
 
-        if dialect_name in SQLTableStore.__registered_dialects:
-            warnings.warn(
-                f"Already registered a SQLTableStore for dialect {dialect_name}"
-            )
-        SQLTableStore.__registered_dialects[dialect_name] = cls
+        if dialect_name != DISABLE_DIALECT_REGISTRATION:
+            if dialect_name in SQLTableStore.__registered_dialects:
+                warnings.warn(
+                    f"Already registered a SQLTableStore for dialect {dialect_name}"
+                )
+            SQLTableStore.__registered_dialects[dialect_name] = cls
 
     def _metadata_pk(self, name: str, table_name: str):
         return sa.Column(name, sa.BigInteger(), primary_key=True)

--- a/src/pydiverse/pipedag/context/context.py
+++ b/src/pydiverse/pipedag/context/context.py
@@ -240,6 +240,12 @@ class ConfigContext(BaseAttrsContext):
         # Load objects referenced in config
         try:
             table_store_config = self._config_dict["table_store"]
+            # Attention: See SQLTableStore.__new__ for how this call may instantiate
+            # a subclass of table_store_config["class"] depending on engine URL.
+            # For testing, we also allow setting table_store_config["class"] to an
+            # actual class. In case you want to create a table store that does not
+            # replace the default derived class for a specific dialect, set
+            # `_dialect_name = DISABLE_DIALECT_REGISTRATION`.
             table_store = load_object(table_store_config)
         except Exception as e:
             raise RuntimeError("Failed loading table_store") from e

--- a/src/pydiverse/pipedag/util/import_.py
+++ b/src/pydiverse/pipedag/util/import_.py
@@ -112,7 +112,11 @@ def load_object(config_dict: dict, move_keys_into_args: Collection[str] | None =
             "section that supports multiple backends\n"
             f"config section: {config_dict}"
         )
-    cls = import_object(config_dict["class"])
+    if isinstance(config_dict["class"], type):
+        # it may be useful in tests to just pass in a dynamically created class
+        cls = config_dict["class"]
+    else:
+        cls = import_object(config_dict["class"])
 
     args = config_dict.get("args", {}) or {}
     if not isinstance(args, dict):

--- a/tests/test_table_hooks/test_pandas.py
+++ b/tests/test_table_hooks/test_pandas.py
@@ -332,80 +332,80 @@ class TestPandasAutoVersion:
 
 
 @with_instances("postgres")
-def test_custom_upload():
-    @ConfigContext.get().store.table_store.register_table(
-        pd, previous_hook_replace="PandasTableHook"
-    )
-    class CustomPandasTableHook(PandasTableHook):
-        @classmethod
-        def upload_table(
-            cls,
-            df: pd.DataFrame,
-            name: str,
-            schema: str,
-            dtypes: dict[str, DType],
-            conn: sa.Connection,
-            early: bool,
-        ):
-            df["custom_upload"] = True
-            super().upload_table(df, name, schema, dtypes, conn, early)
+class TestPandasCustomHook:
+    @with_instances("postgres")
+    def test_custom_upload(self):
+        @ConfigContext.get().store.table_store.register_table(
+            pd, previous_hook_replace="PandasTableHook"
+        )
+        class CustomPandasUploadTableHook(PandasTableHook):
+            @classmethod
+            def upload_table(
+                cls,
+                df: pd.DataFrame,
+                name: str,
+                schema: str,
+                dtypes: dict[str, DType],
+                conn: sa.Connection,
+                early: bool,
+            ):
+                df["custom_upload"] = True
+                super().upload_table(df, name, schema, dtypes, conn, early)
 
-    df = pd.DataFrame(
-        {
-            "int8": pd.array(Values.INT8, dtype="Int8"),
-        }
-    )
+        df = pd.DataFrame(
+            {
+                "int8": pd.array(Values.INT8, dtype="Int8"),
+            }
+        )
 
-    @materialize()
-    def numpy_input():
-        return df
-
-    @materialize(input_type=pd.DataFrame)
-    def verify_cutom(t):
-        assert "custom_upload" in t.columns
-
-    with Flow() as f:
-        with Stage("stage"):
-            t = numpy_input()
-            verify_cutom(t)
-
-    assert f.run().successful
-
-
-@with_instances("postgres")
-def test_custom_download():
-    @ConfigContext.get().store.table_store.register_table(
-        pd, previous_hook_replace="PandasTableHook"
-    )
-    class CustomPandasTableHook(PandasTableHook):
-        @classmethod
-        def download_table(
-            cls,
-            query: Any,
-            conn: sa.Connection,
-            dtypes: dict[str, DType] | None = None,
-        ):
-            df = super().download_table(query, conn, dtypes)
-            df["custom_download"] = True
+        @materialize()
+        def numpy_input():
             return df
 
-    df = pd.DataFrame(
-        {
-            "int8": pd.array(Values.INT8, dtype="Int8"),
-        }
-    )
+        @materialize(input_type=pd.DataFrame)
+        def verify_cutom(t):
+            assert "custom_upload" in t.columns
 
-    @materialize()
-    def numpy_input():
-        return df
+        with Flow() as f:
+            with Stage("stage"):
+                t = numpy_input()
+                verify_cutom(t)
 
-    @materialize(input_type=pd.DataFrame)
-    def verify_cutom(t):
-        assert "custom_download" in t.columns
+        assert f.run().successful
 
-    with Flow() as f:
-        with Stage("stage"):
-            t = numpy_input()
-            verify_cutom(t)
+    def test_custom_download(self):
+        @ConfigContext.get().store.table_store.register_table(
+            pd, previous_hook_replace="CustomPandasUploadTableHook"
+        )
+        class CustomPandasDownloadTableHook(PandasTableHook):
+            @classmethod
+            def download_table(
+                cls,
+                query: Any,
+                conn: sa.Connection,
+                dtypes: dict[str, DType] | None = None,
+            ):
+                df = super().download_table(query, conn, dtypes)
+                df["custom_download"] = True
+                return df
 
-    assert f.run().successful
+        df = pd.DataFrame(
+            {
+                "int8": pd.array(Values.INT8, dtype="Int8"),
+            }
+        )
+
+        @materialize()
+        def numpy_input():
+            return df
+
+        @materialize(input_type=pd.DataFrame)
+        def verify_cutom(t):
+            assert "custom_download" in t.columns
+
+        with Flow() as f:
+            with Stage("stage"):
+                t = numpy_input()
+                verify_cutom(t)
+
+        assert f.run().successful

--- a/tests/test_table_hooks/test_pandas.py
+++ b/tests/test_table_hooks/test_pandas.py
@@ -333,7 +333,6 @@ class TestPandasAutoVersion:
 
 @with_instances("postgres")
 class TestPandasCustomHook:
-    @with_instances("postgres")
     def test_custom_upload(self):
         @ConfigContext.get().store.table_store.register_table(
             pd, previous_hook_replace="PandasTableHook"

--- a/tests/test_table_hooks/test_pandas_hook.py
+++ b/tests/test_table_hooks/test_pandas_hook.py
@@ -339,7 +339,11 @@ class TestPandasCustomHook:
             # this subclass is just to make sure hooks of other tests are not affected
             pass
 
-        cfg = get_config_with_table_store(ConfigContext.get(), TestTableStore)
+        class TestTableStore2(TestTableStore):
+            # this tests that the delegation to parent hooks works
+            pass
+
+        cfg = get_config_with_table_store(ConfigContext.get(), TestTableStore2)
 
         @TestTableStore.register_table(pd, replace_hooks=[PandasTableHook])
         class CustomPandasUploadTableHook(PandasTableHook):

--- a/tests/test_table_hooks/test_pandas_hook.py
+++ b/tests/test_table_hooks/test_pandas_hook.py
@@ -13,6 +13,7 @@ from packaging.version import Version
 import tests.util.tasks_library as m
 from pydiverse.pipedag import *
 from pydiverse.pipedag.backend.table.sql.hooks import PandasTableHook
+from pydiverse.pipedag.backend.table.sql.sql import DISABLE_DIALECT_REGISTRATION
 from pydiverse.pipedag.backend.table.util import DType
 
 # Parameterize all tests in this file with several instance_id configurations
@@ -336,6 +337,7 @@ class TestPandasAutoVersion:
 class TestPandasCustomHook:
     def test_custom_upload(self):
         class TestTableStore(ConfigContext.get().store.table_store.__class__):
+            _dialect_name = DISABLE_DIALECT_REGISTRATION
             # this subclass is just to make sure hooks of other tests are not affected
             pass
 
@@ -383,6 +385,7 @@ class TestPandasCustomHook:
 
     def test_custom_download(self):
         class TestTableStore(ConfigContext.get().store.table_store.__class__):
+            _dialect_name = DISABLE_DIALECT_REGISTRATION
             # this subclass is just to make sure hooks of other tests are not affected
             pass
 

--- a/tests/test_table_hooks/test_pandas_hook.py
+++ b/tests/test_table_hooks/test_pandas_hook.py
@@ -388,7 +388,7 @@ class TestPandasCustomHook:
 
         cfg = get_config_with_table_store(ConfigContext.get(), TestTableStore)
 
-        @TestTableStore.register_table(pd, replace_hooks="CustomPandasUploadTableHook")
+        @TestTableStore.register_table(pd, replace_hooks=[PandasTableHook])
         class CustomPandasDownloadTableHook(PandasTableHook):
             @classmethod
             def download_table(

--- a/tests/test_table_hooks/test_pandas_hook.py
+++ b/tests/test_table_hooks/test_pandas_hook.py
@@ -341,7 +341,7 @@ class TestPandasCustomHook:
 
         cfg = get_config_with_table_store(ConfigContext.get(), TestTableStore)
 
-        @TestTableStore.register_table(pd, previous_hook_replace=[PandasTableHook])
+        @TestTableStore.register_table(pd, replace_hooks=[PandasTableHook])
         class CustomPandasUploadTableHook(PandasTableHook):
             @classmethod
             def upload_table(
@@ -384,9 +384,7 @@ class TestPandasCustomHook:
 
         cfg = get_config_with_table_store(ConfigContext.get(), TestTableStore)
 
-        @TestTableStore.register_table(
-            pd, previous_hook_replace="CustomPandasUploadTableHook"
-        )
+        @TestTableStore.register_table(pd, replace_hooks="CustomPandasUploadTableHook")
         class CustomPandasDownloadTableHook(PandasTableHook):
             @classmethod
             def download_table(

--- a/tests/test_table_hooks/test_polars.py
+++ b/tests/test_table_hooks/test_polars.py
@@ -9,7 +9,7 @@ from pydiverse.pipedag.backend.table.sql.hooks import PolarsTableHook
 from pydiverse.pipedag.backend.table.sql.sql import DISABLE_DIALECT_REGISTRATION
 
 # Parameterize all tests in this file with several instance_id configurations
-from tests.fixtures.instances import DATABASE_INSTANCES, with_instances
+from tests.fixtures.instances import DATABASE_INSTANCES, skip_instances, with_instances
 from tests.util.spy import spy_task
 from tests.util.sql import get_config_with_table_store
 from tests.util.tasks_library import assert_table_equal
@@ -168,6 +168,7 @@ def test_auto_version_2(mocker):
     in_tables_spy.assert_called(2)
 
 
+@skip_instances("duckdb")
 def test_custom_download():
     class TestTableStore(ConfigContext.get().store.table_store.__class__):
         _dialect_name = DISABLE_DIALECT_REGISTRATION
@@ -184,6 +185,7 @@ def test_custom_download():
             query: Any,
             connection_uri: str,
         ):
+            # FYI: this fails for duckdb and thus we fall back to pandas hook
             df = pl.read_database(query, connection_uri)
             return df.with_columns(pl.lit(True).alias("custom_download"))
 

--- a/tests/test_table_hooks/test_polars.py
+++ b/tests/test_table_hooks/test_polars.py
@@ -174,7 +174,7 @@ def test_custom_download():
 
     cfg = get_config_with_table_store(ConfigContext.get(), TestTableStore)
 
-    @TestTableStore.register_table(pl, previous_hook_replace="PolarsTableHook")
+    @TestTableStore.register_table(pl, replace_hooks=[PolarsTableHook])
     class CustomPolarsDownloadTableHook(PolarsTableHook):
         @classmethod
         def download_table(

--- a/tests/test_table_hooks/test_polars.py
+++ b/tests/test_table_hooks/test_polars.py
@@ -6,6 +6,7 @@ import pytest
 
 from pydiverse.pipedag import *
 from pydiverse.pipedag.backend.table.sql.hooks import PolarsTableHook
+from pydiverse.pipedag.backend.table.sql.sql import DISABLE_DIALECT_REGISTRATION
 
 # Parameterize all tests in this file with several instance_id configurations
 from tests.fixtures.instances import DATABASE_INSTANCES, with_instances
@@ -169,6 +170,7 @@ def test_auto_version_2(mocker):
 
 def test_custom_download():
     class TestTableStore(ConfigContext.get().store.table_store.__class__):
+        _dialect_name = DISABLE_DIALECT_REGISTRATION
         # this subclass is just to make sure hooks of other tests are not affected
         pass
 

--- a/tests/util/sql.py
+++ b/tests/util/sql.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import copy
+
 import sqlalchemy as sa
 
 from pydiverse.pipedag.backend import BaseTableStore
@@ -37,7 +39,7 @@ def get_config_with_table_store(
     instance = base_cfg.instance_name
     flow = base_cfg.flow_name
     cfg = ConfigContext.new(
-        base_cfg._config_dict, base_cfg.pipedag_name, flow, instance
+        copy.deepcopy(base_cfg._config_dict), base_cfg.pipedag_name, flow, instance
     )
     cfg._config_dict["table_store"]["class"] = table_store_class
     # this actually instantiates the table store

--- a/tests/util/sql.py
+++ b/tests/util/sql.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sqlalchemy as sa
 
+from pydiverse.pipedag.backend import BaseTableStore
 from pydiverse.pipedag.context import ConfigContext
 
 
@@ -28,3 +29,18 @@ def sql_table_expr(cols: dict):
 def compile_sql(query):
     engine = ConfigContext.get().store.table_store.engine
     return str(query.compile(engine, compile_kwargs={"literal_binds": True}))
+
+
+def get_config_with_table_store(
+    base_cfg: ConfigContext, table_store_class: type[BaseTableStore]
+):
+    instance = base_cfg.instance_name
+    flow = base_cfg.flow_name
+    cfg = ConfigContext.new(
+        base_cfg._config_dict, base_cfg.pipedag_name, flow, instance
+    )
+    cfg._config_dict["table_store"]["class"] = table_store_class
+    # this actually instantiates the table store
+    table_store = cfg.store.table_store
+    assert type(table_store) == table_store_class
+    return cfg

--- a/tests/util/tasks_library.py
+++ b/tests/util/tasks_library.py
@@ -106,8 +106,7 @@ def assert_equal(x, y):
 @materialize(input_type=pd.DataFrame)
 def assert_table_equal(x, y, **kwargs):
     # This function explicitly has no version set to prevent it from getting cached
-    assert set(x.columns) == set(y.columns)
-    pd.testing.assert_frame_equal(x, y[x.columns], **kwargs)
+    pd.testing.assert_frame_equal(x, y, **kwargs)
 
 
 @materialize()


### PR DESCRIPTION
- Added `replace_hooks` argument for `register_table`. This avoids reliance on import order.
Given hooks are removed from the table store for which the new hook is registered. If the replace_hooks are located in parent classes, they have lower priority anyways. Please, note, that replace_hooks argument is not effective in case the replacement hooks was registered on a subclass of the table store where the new hook is added. 
If `replace_hooks=None`, the new hook is just added to the list of available hooks.

- Added another hook for download of polars Tables (FYI @nicolasmueller )