### PR TITLE
feat(): add truncation of primary keys and indexes

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.9.4 (XXX)
-- Primary key and index identifiers are now automatically truncated at 63 characters to avoid issues with some database systems.
+- Primary key and index identifiers are now automatically truncated to 63 characters to avoid issues with some database systems.
 
 ## 0.9.3 (2024-06-11)
 - Added `upload_table()` and `download_table()` functions to the PandasTableHook to allow for easy 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.9.4 (XXX)
+- Primary key and index identifiers are now automatically truncated at 63 characters to avoid issues with some database systems.
+
 ## 0.9.3 (2024-06-11)
 - Added `upload_table()` and `download_table()` functions to the PandasTableHook to allow for easy 
     customization of up and download behavior of pandas and polars tables from/to the table store.

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -36,5 +36,6 @@ def test_materialize_table_with_indexes(task):
             x = task()
 
             m.assert_table_equal(x, x)
+            m.check_pk_length(x)
 
     assert f.run().successful

--- a/tests/util/tasks_library.py
+++ b/tests/util/tasks_library.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import pandas as pd
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 from pydiverse.pipedag import Blob, RawSql, Table, materialize
+from pydiverse.pipedag.backend.table.sql.ddl import MAX_LENGTH_PK
 from pydiverse.pipedag.context import TaskContext
 from pydiverse.pipedag.debug import materialize_table
 from tests.util import select_as
@@ -396,3 +398,11 @@ def exception(x, r: bool):
 
 def get_task_logger():
     return TaskContext.get().task.logger
+
+
+@materialize(input_type=sa.Table)
+def check_pk_length(x: sa.Table):
+    pks = inspect(x).primary_key
+    if isinstance(pks, list):
+        pk_name = pks[0].name
+        assert len(pk_name) <= MAX_LENGTH_PK


### PR DESCRIPTION
MSSQL does not allow identifiers longer than 128 characters. 
Similarly, postgres automatically truncates identifiers at 63 characters.
This PR automatically truncates all primary key and index identifiers at 63 characters.

# Checklist

- [x] Added a `docs/source/changelog.md` entry
- [ ] Added/updated documentation in `docs/source/`
- [ ] Added/updated examples in `docs/source/examples.md`
