### PR TITLE
feat(): Added ignore_position_hash option for SQLTableStore

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.9.4 (XXX)
+- Added `ignore_position_hashes` option to `SQLTableStore`. 
+    If `True`, the position hashes of tasks are not checked when retrieving the inputs of a task from the cache.
+    This can prevent caching errors when evaluating subgraphs. 
+    For this to work a task may never be used more than once per stage.
+
+
 ## 0.9.3 (2024-06-11)
 - Added `upload_table()` and `download_table()` functions to the PandasTableHook to allow for easy 
     customization of up and download behavior of pandas and polars tables from/to the table store.

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.9.4 (XXX)
-- Added `ignore_position_hashes` option to `SQLTableStore`. 
+- Added `ignore_position_hashes` option to `flow.run()` and `get_output_from_store()`. 
     If `True`, the position hashes of tasks are not checked when retrieving the inputs of a task from the cache.
     This can prevent caching errors when evaluating subgraphs. 
     For this to work a task may never be used more than once per stage.

--- a/pipedag.yaml
+++ b/pipedag.yaml
@@ -96,13 +96,6 @@ instances:
     blob_store:
       blob_store_connection: no_blob
 
-  postgres_ignore_position_hashes:
-    instance_id: pd_postgres_ignore_position_hashes
-    table_store:
-      table_store_connection: postgres
-      args:
-          ignore_position_hashes: true
-
   mssql:
     instance_id: pd_mssql
     table_store:

--- a/pipedag.yaml
+++ b/pipedag.yaml
@@ -96,6 +96,13 @@ instances:
     blob_store:
       blob_store_connection: no_blob
 
+  postgres_ignore_position_hashes:
+    instance_id: pd_postgres_ignore_position_hashes
+    table_store:
+      table_store_connection: postgres
+      args:
+          ignore_position_hashes: true
+
   mssql:
     instance_id: pd_mssql
     table_store:

--- a/src/pydiverse/pipedag/backend/table/base.py
+++ b/src/pydiverse/pipedag/backend/table/base.py
@@ -617,7 +617,7 @@ class BaseTableStore(TableHookResolver, Disposable):
         """
 
     @abstractmethod
-    def retrieve_all_task_metadata(self, task: MaterializingTask) -> list[TaskMetadata]:
+    def retrieve_all_task_metadata(self, task: MaterializingTask, ignore_position_hashes: bool) -> list[TaskMetadata]:
         """Retrieves all metadata objects associated with a task from the store
 
         As long as a metadata entry has the same task and stage name, as well

--- a/src/pydiverse/pipedag/backend/table/base.py
+++ b/src/pydiverse/pipedag/backend/table/base.py
@@ -618,7 +618,7 @@ class BaseTableStore(TableHookResolver, Disposable):
 
     @abstractmethod
     def retrieve_all_task_metadata(
-        self, task: MaterializingTask, ignore_position_hashes: bool
+        self, task: MaterializingTask, ignore_position_hashes: bool = False
     ) -> list[TaskMetadata]:
         """Retrieves all metadata objects associated with a task from the store
 

--- a/src/pydiverse/pipedag/backend/table/base.py
+++ b/src/pydiverse/pipedag/backend/table/base.py
@@ -617,7 +617,9 @@ class BaseTableStore(TableHookResolver, Disposable):
         """
 
     @abstractmethod
-    def retrieve_all_task_metadata(self, task: MaterializingTask, ignore_position_hashes: bool) -> list[TaskMetadata]:
+    def retrieve_all_task_metadata(
+        self, task: MaterializingTask, ignore_position_hashes: bool
+    ) -> list[TaskMetadata]:
         """Retrieves all metadata objects associated with a task from the store
 
         As long as a metadata entry has the same task and stage name, as well

--- a/src/pydiverse/pipedag/backend/table/dict.py
+++ b/src/pydiverse/pipedag/backend/table/dict.py
@@ -97,13 +97,13 @@ class DictTableStore(BaseTableStore):
                 f"'{task.name}' with cache key '{task.input_hash}', yet"
             ) from None
 
-    def retrieve_all_task_metadata(self, task: MaterializingTask) -> list[TaskMetadata]:
+    def retrieve_all_task_metadata(self, task: MaterializingTask, ignore_position_hashes: bool) -> list[TaskMetadata]:
         task_metadata = []
         for m in (
             *self.metadata[task.stage].values(),
             *self.t_metadata[task.stage].values(),
         ):
-            if m.name == task.name and m.position_hash == task.position_hash:
+            if m.name == task.name and ((m.position_hash == task.position_hash) or ignore_position_hashes):
                 task_metadata.append(m)
         return task_metadata
 

--- a/src/pydiverse/pipedag/backend/table/dict.py
+++ b/src/pydiverse/pipedag/backend/table/dict.py
@@ -98,7 +98,7 @@ class DictTableStore(BaseTableStore):
             ) from None
 
     def retrieve_all_task_metadata(
-        self, task: MaterializingTask, ignore_position_hashes: bool
+        self, task: MaterializingTask, ignore_position_hashes: bool = False
     ) -> list[TaskMetadata]:
         task_metadata = []
         for m in (

--- a/src/pydiverse/pipedag/backend/table/dict.py
+++ b/src/pydiverse/pipedag/backend/table/dict.py
@@ -97,13 +97,17 @@ class DictTableStore(BaseTableStore):
                 f"'{task.name}' with cache key '{task.input_hash}', yet"
             ) from None
 
-    def retrieve_all_task_metadata(self, task: MaterializingTask, ignore_position_hashes: bool) -> list[TaskMetadata]:
+    def retrieve_all_task_metadata(
+        self, task: MaterializingTask, ignore_position_hashes: bool
+    ) -> list[TaskMetadata]:
         task_metadata = []
         for m in (
             *self.metadata[task.stage].values(),
             *self.t_metadata[task.stage].values(),
         ):
-            if m.name == task.name and ((m.position_hash == task.position_hash) or ignore_position_hashes):
+            if m.name == task.name and (
+                (m.position_hash == task.position_hash) or ignore_position_hashes
+            ):
                 task_metadata.append(m)
         return task_metadata
 

--- a/src/pydiverse/pipedag/backend/table/sql/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql/sql.py
@@ -182,6 +182,11 @@ class SQLTableStore(BaseTableStore):
         The number of seconds to wait before giving up on getting a connection from
         the pool. This may be relevant in case the connection pool is saturated
         with concurrent operations each working with one or more database connections.
+    :param ignore_position_hashes:
+        If ``True``, the position hashes of tasks are not checked
+        when retrieving the inputs of a task from the cache.
+        This can prevent caching errors when evaluating subgraphs.
+        For this to work a task may never be used more than once per stage.
     """
 
     METADATA_SCHEMA = "pipedag_metadata"
@@ -223,6 +228,7 @@ class SQLTableStore(BaseTableStore):
         max_concurrent_copy_operations: int = 5,
         sqlalchemy_pool_size: int = 12,
         sqlalchemy_pool_timeout: int = 300,
+        ignore_position_hashes: bool = False,
     ):
         super().__init__()
 
@@ -237,6 +243,7 @@ class SQLTableStore(BaseTableStore):
         self.max_concurrent_copy_operations = max_concurrent_copy_operations
         self.sqlalchemy_pool_size = sqlalchemy_pool_size
         self.squalchemy_pool_timeout = sqlalchemy_pool_timeout
+        self.ignore_position_hashes = ignore_position_hashes
 
         self.metadata_schema = self.get_schema(self.METADATA_SCHEMA)
         self.engine_url = sa.engine.make_url(engine_url)
@@ -1389,18 +1396,23 @@ class SQLTableStore(BaseTableStore):
         )
 
     def retrieve_all_task_metadata(self, task: MaterializingTask) -> list[TaskMetadata]:
+        if self.ignore_position_hashes:
+            match_condition = sa.and_(
+                self.tasks_table.c.name == task.name,
+                self.tasks_table.c.stage == task.stage.name,
+            )
+        else:
+            match_condition = sa.and_(
+                self.tasks_table.c.name == task.name,
+                self.tasks_table.c.stage == task.stage.name,
+                self.tasks_table.c.position_hash == task.position_hash,
+            )
         with self.engine_connect() as conn:
             results = (
-                conn.execute(
-                    self.tasks_table.select()
-                    .where(self.tasks_table.c.name == task.name)
-                    .where(self.tasks_table.c.stage == task.stage.name)
-                    .where(self.tasks_table.c.position_hash == task.position_hash)
-                )
+                conn.execute(self.tasks_table.select().where(match_condition))
                 .mappings()
                 .all()
             )
-
         return [
             TaskMetadata(
                 name=result.name,

--- a/src/pydiverse/pipedag/backend/table/sql/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql/sql.py
@@ -182,11 +182,6 @@ class SQLTableStore(BaseTableStore):
         The number of seconds to wait before giving up on getting a connection from
         the pool. This may be relevant in case the connection pool is saturated
         with concurrent operations each working with one or more database connections.
-    :param ignore_position_hashes:
-        If ``True``, the position hashes of tasks are not checked
-        when retrieving the inputs of a task from the cache.
-        This can prevent caching errors when evaluating subgraphs.
-        For this to work a task may never be used more than once per stage.
     """
 
     METADATA_SCHEMA = "pipedag_metadata"
@@ -228,7 +223,6 @@ class SQLTableStore(BaseTableStore):
         max_concurrent_copy_operations: int = 5,
         sqlalchemy_pool_size: int = 12,
         sqlalchemy_pool_timeout: int = 300,
-        ignore_position_hashes: bool = False,
     ):
         super().__init__()
 
@@ -243,7 +237,6 @@ class SQLTableStore(BaseTableStore):
         self.max_concurrent_copy_operations = max_concurrent_copy_operations
         self.sqlalchemy_pool_size = sqlalchemy_pool_size
         self.squalchemy_pool_timeout = sqlalchemy_pool_timeout
-        self.ignore_position_hashes = ignore_position_hashes
 
         self.metadata_schema = self.get_schema(self.METADATA_SCHEMA)
         self.engine_url = sa.engine.make_url(engine_url)
@@ -1395,18 +1388,14 @@ class SQLTableStore(BaseTableStore):
             output_json=result.output_json,
         )
 
-    def retrieve_all_task_metadata(self, task: MaterializingTask) -> list[TaskMetadata]:
-        if self.ignore_position_hashes:
-            match_condition = sa.and_(
-                self.tasks_table.c.name == task.name,
-                self.tasks_table.c.stage == task.stage.name,
-            )
-        else:
-            match_condition = sa.and_(
-                self.tasks_table.c.name == task.name,
-                self.tasks_table.c.stage == task.stage.name,
-                self.tasks_table.c.position_hash == task.position_hash,
-            )
+    def retrieve_all_task_metadata(self, task: MaterializingTask, ignore_position_hashes: bool) -> list[TaskMetadata]:
+        match_condition = sa.and_(
+            self.tasks_table.c.name == task.name,
+            self.tasks_table.c.stage == task.stage.name,
+        )
+
+        if not self.ignore_position_hashes:
+            match_condition = match_condition & (self.tasks_table.c.position_hash == task.position_hash)
         with self.engine_connect() as conn:
             results = (
                 conn.execute(self.tasks_table.select().where(match_condition))

--- a/src/pydiverse/pipedag/backend/table/sql/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql/sql.py
@@ -1396,7 +1396,7 @@ class SQLTableStore(BaseTableStore):
             self.tasks_table.c.stage == task.stage.name,
         )
 
-        if not self.ignore_position_hashes:
+        if not ignore_position_hashes:
             match_condition = match_condition & (
                 self.tasks_table.c.position_hash == task.position_hash
             )

--- a/src/pydiverse/pipedag/backend/table/sql/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql/sql.py
@@ -1388,14 +1388,18 @@ class SQLTableStore(BaseTableStore):
             output_json=result.output_json,
         )
 
-    def retrieve_all_task_metadata(self, task: MaterializingTask, ignore_position_hashes: bool) -> list[TaskMetadata]:
+    def retrieve_all_task_metadata(
+        self, task: MaterializingTask, ignore_position_hashes: bool
+    ) -> list[TaskMetadata]:
         match_condition = sa.and_(
             self.tasks_table.c.name == task.name,
             self.tasks_table.c.stage == task.stage.name,
         )
 
         if not self.ignore_position_hashes:
-            match_condition = match_condition & (self.tasks_table.c.position_hash == task.position_hash)
+            match_condition = match_condition & (
+                self.tasks_table.c.position_hash == task.position_hash
+            )
         with self.engine_connect() as conn:
             results = (
                 conn.execute(self.tasks_table.select().where(match_condition))

--- a/src/pydiverse/pipedag/backend/table/sql/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql/sql.py
@@ -1389,7 +1389,7 @@ class SQLTableStore(BaseTableStore):
         )
 
     def retrieve_all_task_metadata(
-        self, task: MaterializingTask, ignore_position_hashes: bool
+        self, task: MaterializingTask, ignore_position_hashes: bool = False
     ) -> list[TaskMetadata]:
         match_condition = sa.and_(
             self.tasks_table.c.name == task.name,

--- a/src/pydiverse/pipedag/core/flow.py
+++ b/src/pydiverse/pipedag/core/flow.py
@@ -254,6 +254,7 @@ class Flow:
         cache_validation_mode: CacheValidationMode | None = None,
         disable_cache_function: bool | None = None,
         ignore_task_version: bool | None = None,
+        ignore_position_hashes: bool = False,
         **kwargs,
     ) -> Result:
         """Execute the flow.
@@ -292,6 +293,11 @@ class Flow:
             Override the ignore_task_version setting from the config.
             See :doc:`/reference/config` :ref:`section-cache_validation` for more
             information.
+        :param ignore_position_hashes:
+            If ``True``, the position hashes of tasks are not checked
+            when retrieving the inputs of a task from the cache.
+            This can prevent caching errors when evaluating subgraphs.
+            For this to work a task may never be used more than once per stage.
         :param kwargs:
             Other keyword arguments that get passed on directly to the
             ``run()`` method of the orchestration engine. Consequently, these
@@ -365,7 +371,7 @@ class Flow:
         with config, RunContextServer(subflow):
             if orchestration_engine is None:
                 orchestration_engine = config.create_orchestration_engine()
-            result = orchestration_engine.run(subflow, **kwargs)
+            result = orchestration_engine.run(subflow, ignore_position_hashes, **kwargs)
 
             visualization_url = result.visualize_url()
             self.logger.info("Flow visualization", url=visualization_url)

--- a/src/pydiverse/pipedag/core/flow.py
+++ b/src/pydiverse/pipedag/core/flow.py
@@ -296,8 +296,13 @@ class Flow:
         :param ignore_position_hashes:
             If ``True``, the position hashes of tasks are not checked
             when retrieving the inputs of a task from the cache.
-            This simplifies execution of subgraphs if you don't care whether inputs to that subgraph are cache invalid. This allows multiple modifications in the Graph before the next run updating the cache.
-            Attention: This may break automatic cache invalidation. And for this to work, any task producing an input for the chosen subgraph may never be used more than once per stage.
+            This simplifies execution of subgraphs if you don't care whether inputs to
+            that subgraph are cache invalid. This allows multiple modifications in the
+            Graph before the next run updating the cache.
+            Attention: This may break automatic cache invalidation.
+            And for this to work, any task producing an input
+            for the chosen subgraph may never be used more
+            than once per stage.
         :param kwargs:
             Other keyword arguments that get passed on directly to the
             ``run()`` method of the orchestration engine. Consequently, these
@@ -328,7 +333,12 @@ class Flow:
             flow.run(task_1, task_4)
 
         """
-
+        self.logger.warn(
+            "Using ignore_position_hashes=True! "
+            "This may break automatic cache invalidation. "
+            "And for this to work, any task producing an "
+            "input for the chosen subgraph may never be used more than once per stage."
+        )
         subflow = self.get_subflow(*components)
 
         # Get the ConfigContext to use

--- a/src/pydiverse/pipedag/core/flow.py
+++ b/src/pydiverse/pipedag/core/flow.py
@@ -296,7 +296,7 @@ class Flow:
         :param ignore_position_hashes:
             If ``True``, the position hashes of tasks are not checked
             when retrieving the inputs of a task from the cache.
-            This can prevent caching errors when evaluating subgraphs.
+            This simplifies execution of subgraphs if you don't care whether inputs to that subgraph are cache invalid. This allows multiple modifications in the Graph before the next run updating the cache.
             For this to work a task may never be used more than once per stage.
         :param kwargs:
             Other keyword arguments that get passed on directly to the

--- a/src/pydiverse/pipedag/core/flow.py
+++ b/src/pydiverse/pipedag/core/flow.py
@@ -297,7 +297,7 @@ class Flow:
             If ``True``, the position hashes of tasks are not checked
             when retrieving the inputs of a task from the cache.
             This simplifies execution of subgraphs if you don't care whether inputs to that subgraph are cache invalid. This allows multiple modifications in the Graph before the next run updating the cache.
-            For this to work a task may never be used more than once per stage.
+            Attention: This may break automatic cache invalidation. And for this to work, any task producing an input for the chosen subgraph may never be used more than once per stage.
         :param kwargs:
             Other keyword arguments that get passed on directly to the
             ``run()`` method of the orchestration engine. Consequently, these

--- a/src/pydiverse/pipedag/core/task.py
+++ b/src/pydiverse/pipedag/core/task.py
@@ -167,6 +167,7 @@ class Task:
         inputs: dict[int, Any],
         run_context: RunContext = None,
         config_context: ConfigContext = None,
+        ignore_position_hashes: bool=False
     ):
         # Hand over run context if using multiprocessing
         if run_context is None:

--- a/src/pydiverse/pipedag/core/task.py
+++ b/src/pydiverse/pipedag/core/task.py
@@ -167,7 +167,7 @@ class Task:
         inputs: dict[int, Any],
         run_context: RunContext = None,
         config_context: ConfigContext = None,
-        ignore_position_hashes: bool=False
+        ignore_position_hashes: bool = False,
     ):
         # Hand over run context if using multiprocessing
         if run_context is None:

--- a/src/pydiverse/pipedag/engine/base.py
+++ b/src/pydiverse/pipedag/engine/base.py
@@ -13,7 +13,9 @@ class OrchestrationEngine(Disposable, ABC):
     """Flow orchestration engine base class"""
 
     @abstractmethod
-    def run(self, flow: Subflow, ignore_position_hashes: bool, **kwargs) -> Result:
+    def run(
+        self, flow: Subflow, ignore_position_hashes: bool = False, **kwargs
+    ) -> Result:
         """Execute a flow
 
         :param flow: the pipedag flow to execute

--- a/src/pydiverse/pipedag/engine/base.py
+++ b/src/pydiverse/pipedag/engine/base.py
@@ -19,6 +19,16 @@ class OrchestrationEngine(Disposable, ABC):
         """Execute a flow
 
         :param flow: the pipedag flow to execute
+        :param ignore_position_hashes:
+            If ``True``, the position hashes of tasks are not checked
+            when retrieving the inputs of a task from the cache.
+            This simplifies execution of subgraphs if you don't care whether inputs to
+            that subgraph are cache invalid. This allows multiple modifications in the
+            Graph before the next run updating the cache.
+            Attention: This may break automatic cache invalidation.
+            And for this to work, any task producing an input
+            for the chosen subgraph may never be used more
+            than once per stage.
         :param kwargs: Optional keyword arguments. How they get used is
             engine specific.
         :return: A result instance wrapping the flow execution result.

--- a/src/pydiverse/pipedag/engine/base.py
+++ b/src/pydiverse/pipedag/engine/base.py
@@ -13,7 +13,7 @@ class OrchestrationEngine(Disposable, ABC):
     """Flow orchestration engine base class"""
 
     @abstractmethod
-    def run(self, flow: Subflow, **kwargs) -> Result:
+    def run(self, flow: Subflow, ignore_position_hashes: bool, **kwargs) -> Result:
         """Execute a flow
 
         :param flow: the pipedag flow to execute

--- a/src/pydiverse/pipedag/engine/dask.py
+++ b/src/pydiverse/pipedag/engine/dask.py
@@ -45,7 +45,7 @@ class DaskEngine(OrchestrationEngine):
 
         self.dask_compute_kwargs.update(dask_compute_kwargs)
 
-    def run(self, flow: Subflow, **run_kwargs):
+    def run(self, flow: Subflow, ignore_position_hashes: bool, **run_kwargs):
         run_context = RunContext.get()
         config_context = ConfigContext.get()
 

--- a/src/pydiverse/pipedag/engine/dask.py
+++ b/src/pydiverse/pipedag/engine/dask.py
@@ -45,7 +45,7 @@ class DaskEngine(OrchestrationEngine):
 
         self.dask_compute_kwargs.update(dask_compute_kwargs)
 
-    def run(self, flow: Subflow, ignore_position_hashes: bool, **run_kwargs):
+    def run(self, flow: Subflow, ignore_position_hashes: bool = False, **run_kwargs):
         run_context = RunContext.get()
         config_context = ConfigContext.get()
 

--- a/src/pydiverse/pipedag/engine/prefect.py
+++ b/src/pydiverse/pipedag/engine/prefect.py
@@ -87,7 +87,7 @@ class PrefectOneEngine(OrchestrationEngine):
 
         return flow, tasks
 
-    def run(self, flow: Subflow, ignore_position_hashes: bool, **run_kwargs):
+    def run(self, flow: Subflow, ignore_position_hashes: bool = False, **run_kwargs):
         _ = ignore_position_hashes
         prefect_flow, tasks_map = self.construct_prefect_flow(flow)
         result = prefect_flow.run(**run_kwargs)
@@ -176,7 +176,7 @@ class PrefectTwoEngine(OrchestrationEngine):
 
         return pipedag_flow
 
-    def run(self, flow: Subflow, ignore_position_hashes: bool, **kwargs):
+    def run(self, flow: Subflow, ignore_position_hashes: bool = False, **kwargs):
         _ = ignore_position_hashes
         if kwargs:
             raise TypeError(f"{type(self).__name__}.run doesn't take kwargs.")

--- a/src/pydiverse/pipedag/engine/prefect.py
+++ b/src/pydiverse/pipedag/engine/prefect.py
@@ -87,7 +87,8 @@ class PrefectOneEngine(OrchestrationEngine):
 
         return flow, tasks
 
-    def run(self, flow: Subflow, **run_kwargs):
+    def run(self, flow: Subflow, ignore_position_hashes: bool, **run_kwargs):
+        _ = ignore_position_hashes
         prefect_flow, tasks_map = self.construct_prefect_flow(flow)
         result = prefect_flow.run(**run_kwargs)
 
@@ -175,7 +176,8 @@ class PrefectTwoEngine(OrchestrationEngine):
 
         return pipedag_flow
 
-    def run(self, flow: Subflow, **kwargs):
+    def run(self, flow: Subflow, ignore_position_hashes: bool, **kwargs):
+        _ = ignore_position_hashes
         if kwargs:
             raise TypeError(f"{type(self).__name__}.run doesn't take kwargs.")
         prefect_flow = self.construct_prefect_flow(flow)

--- a/src/pydiverse/pipedag/engine/sequential.py
+++ b/src/pydiverse/pipedag/engine/sequential.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 class SequentialEngine(OrchestrationEngine):
     """Most basic orchestration engine that just executes all tasks sequentially."""
 
-    def run(self, flow: Subflow, **run_kwargs):
+    def run(self, flow: Subflow, ignore_position_hashes: bool, **run_kwargs):
         run_context = RunContext.get()
         config_context = ConfigContext.get()
 
@@ -33,6 +33,7 @@ class SequentialEngine(OrchestrationEngine):
                             },
                             run_context=run_context,
                             config_context=config_context,
+                            ignore_position_hashes=ignore_position_hashes,
                         )
                     else:
                         failed_tasks.add(task)

--- a/src/pydiverse/pipedag/engine/sequential.py
+++ b/src/pydiverse/pipedag/engine/sequential.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 class SequentialEngine(OrchestrationEngine):
     """Most basic orchestration engine that just executes all tasks sequentially."""
 
-    def run(self, flow: Subflow, ignore_position_hashes: bool, **run_kwargs):
+    def run(self, flow: Subflow, ignore_position_hashes: bool = False, **run_kwargs):
         run_context = RunContext.get()
         config_context = ConfigContext.get()
 

--- a/src/pydiverse/pipedag/materialize/core.py
+++ b/src/pydiverse/pipedag/materialize/core.py
@@ -462,7 +462,9 @@ class MaterializingTask(Task):
         """
         return MaterializingTaskGetItem(self, self, item)
 
-    def run(self, inputs: dict[int, Any], ignore_position_hashes: bool, **kwargs):
+    def run(
+        self, inputs: dict[int, Any], ignore_position_hashes: bool = False, **kwargs
+    ):
         # When running only a subset of an entire flow, not all inputs
         # get calculated during flow execution. As a consequence, we must load
         # those inputs from the cache.

--- a/src/pydiverse/pipedag/materialize/core.py
+++ b/src/pydiverse/pipedag/materialize/core.py
@@ -486,7 +486,9 @@ class MaterializingTask(Task):
 
         return super().run(inputs, **kwargs)
 
-    def get_output_from_store(self, as_type: type = None) -> Any:
+    def get_output_from_store(
+        self, as_type: type = None, ignore_position_hashes: bool = False
+    ) -> Any:
         """Retrieves the output of the task from the cache.
 
         No guarantees are made regarding whether the returned values are still
@@ -513,7 +515,9 @@ class MaterializingTask(Task):
             df_x = x.get_output_from_store(as_type=pd.DataFrame)
 
         """
-        return _get_output_from_store(self, as_type)
+        return _get_output_from_store(
+            self, as_type, ignore_position_hashes=ignore_position_hashes
+        )
 
 
 class MaterializingTaskGetItem(TaskGetItem):
@@ -538,12 +542,16 @@ class MaterializingTaskGetItem(TaskGetItem):
         """
         return super().__getitem__(item)
 
-    def get_output_from_store(self, as_type: type = None) -> Any:
+    def get_output_from_store(
+        self, as_type: type = None, ignore_position_hashes: bool = False
+    ) -> Any:
         """
         Same as :py:meth:`MaterializingTask.get_output_from_store()`,
         except that it only loads the required subset of the output.
         """
-        return _get_output_from_store(self, as_type)
+        return _get_output_from_store(
+            self, as_type, ignore_position_hashes=ignore_position_hashes
+        )
 
 
 class MaterializationWrapper:

--- a/src/pydiverse/pipedag/materialize/core.py
+++ b/src/pydiverse/pipedag/materialize/core.py
@@ -499,6 +499,16 @@ class MaterializingTask(Task):
         :param as_type: The type as which tables produced by this task should
             be dematerialized. If no type is specified, the input type of
             the task is used.
+        :param ignore_position_hashes:
+            If ``True``, the position hashes of tasks are not checked
+            when retrieving the inputs of a task from the cache.
+            This simplifies execution of subgraphs if you don't care whether inputs to
+            that subgraph are cache invalid. This allows multiple modifications in the
+            Graph before the next run updating the cache.
+            Attention: This may break automatic cache invalidation.
+            And for this to work, any task producing an input
+            for the chosen subgraph may never be used more
+            than once per stage.
         :return: The output of the task.
         :raise CacheError: if no outputs for this task could be found in the store.
 

--- a/src/pydiverse/pipedag/materialize/core.py
+++ b/src/pydiverse/pipedag/materialize/core.py
@@ -462,7 +462,7 @@ class MaterializingTask(Task):
         """
         return MaterializingTaskGetItem(self, self, item)
 
-    def run(self, inputs: dict[int, Any], **kwargs):
+    def run(self, inputs: dict[int, Any], ignore_position_hashes: bool, **kwargs):
         # When running only a subset of an entire flow, not all inputs
         # get calculated during flow execution. As a consequence, we must load
         # those inputs from the cache.
@@ -478,7 +478,7 @@ class MaterializingTask(Task):
 
             store = ConfigContext.get().store
             cached_output, metadata = store.retrieve_most_recent_task_output_from_cache(
-                in_task
+                in_task, ignore_position_hashes
             )
 
             cached_output = deep_map(cached_output, replace_stage_with_pseudo_stage)
@@ -1505,7 +1505,7 @@ def input_stage_versions(
 
 
 def _get_output_from_store(
-    task: MaterializingTask | MaterializingTaskGetItem, as_type: type
+    task: MaterializingTask | MaterializingTaskGetItem, as_type: type, ignore_position_hashes: bool = False
 ) -> Any:
     """Helper to retrieve task output from store"""
     from pydiverse.pipedag.context.run_context import DematerializeRunContext
@@ -1515,7 +1515,7 @@ def _get_output_from_store(
 
     store = ConfigContext.get().store
     with DematerializeRunContext(root_task.flow):
-        cached_output, _ = store.retrieve_most_recent_task_output_from_cache(root_task)
+        cached_output, _ = store.retrieve_most_recent_task_output_from_cache(root_task, ignore_position_hashes=ignore_position_hashes)
         return dematerialize_output_from_store(store, task, cached_output, as_type)
 
 

--- a/src/pydiverse/pipedag/materialize/core.py
+++ b/src/pydiverse/pipedag/materialize/core.py
@@ -1505,7 +1505,9 @@ def input_stage_versions(
 
 
 def _get_output_from_store(
-    task: MaterializingTask | MaterializingTaskGetItem, as_type: type, ignore_position_hashes: bool = False
+    task: MaterializingTask | MaterializingTaskGetItem,
+    as_type: type,
+    ignore_position_hashes: bool = False,
 ) -> Any:
     """Helper to retrieve task output from store"""
     from pydiverse.pipedag.context.run_context import DematerializeRunContext
@@ -1515,7 +1517,9 @@ def _get_output_from_store(
 
     store = ConfigContext.get().store
     with DematerializeRunContext(root_task.flow):
-        cached_output, _ = store.retrieve_most_recent_task_output_from_cache(root_task, ignore_position_hashes=ignore_position_hashes)
+        cached_output, _ = store.retrieve_most_recent_task_output_from_cache(
+            root_task, ignore_position_hashes=ignore_position_hashes
+        )
         return dematerialize_output_from_store(store, task, cached_output, as_type)
 
 

--- a/src/pydiverse/pipedag/materialize/store.py
+++ b/src/pydiverse/pipedag/materialize/store.py
@@ -505,7 +505,7 @@ class PipeDAGStore(Disposable):
         )
 
     def retrieve_most_recent_task_output_from_cache(
-        self, task: MaterializingTask
+        self, task: MaterializingTask, ignore_position_hashes:bool
     ) -> (Materializable, TaskMetadata):
         """
         Retrieves the cached output from the most recent execution of a task.
@@ -522,7 +522,7 @@ class PipeDAGStore(Disposable):
         # This returns all metadata objects with the same name, stage, AND position
         # hash as `task`. We utilize the position hash to identify a specific
         # task instance, if the same task appears multiple times in a stage.
-        metadata = self.table_store.retrieve_all_task_metadata(task)
+        metadata = self.table_store.retrieve_all_task_metadata(task, ignore_position_hashes=ignore_position_hashes)
 
         if not metadata:
             raise CacheError(

--- a/src/pydiverse/pipedag/materialize/store.py
+++ b/src/pydiverse/pipedag/materialize/store.py
@@ -505,7 +505,7 @@ class PipeDAGStore(Disposable):
         )
 
     def retrieve_most_recent_task_output_from_cache(
-        self, task: MaterializingTask, ignore_position_hashes: bool
+        self, task: MaterializingTask, ignore_position_hashes: bool = False
     ) -> (Materializable, TaskMetadata):
         """
         Retrieves the cached output from the most recent execution of a task.

--- a/src/pydiverse/pipedag/materialize/store.py
+++ b/src/pydiverse/pipedag/materialize/store.py
@@ -505,7 +505,7 @@ class PipeDAGStore(Disposable):
         )
 
     def retrieve_most_recent_task_output_from_cache(
-        self, task: MaterializingTask, ignore_position_hashes:bool
+        self, task: MaterializingTask, ignore_position_hashes: bool
     ) -> (Materializable, TaskMetadata):
         """
         Retrieves the cached output from the most recent execution of a task.
@@ -522,7 +522,9 @@ class PipeDAGStore(Disposable):
         # This returns all metadata objects with the same name, stage, AND position
         # hash as `task`. We utilize the position hash to identify a specific
         # task instance, if the same task appears multiple times in a stage.
-        metadata = self.table_store.retrieve_all_task_metadata(task, ignore_position_hashes=ignore_position_hashes)
+        metadata = self.table_store.retrieve_all_task_metadata(
+            task, ignore_position_hashes=ignore_position_hashes
+        )
 
         if not metadata:
             raise CacheError(

--- a/src/pydiverse/pipedag/materialize/store.py
+++ b/src/pydiverse/pipedag/materialize/store.py
@@ -515,6 +515,16 @@ class PipeDAGStore(Disposable):
 
         :param task: The materializing task for which to retrieve
             the cached output.
+        :param ignore_position_hashes:
+            If ``True``, the position hashes of tasks are not checked
+            when retrieving the inputs of a task from the cache.
+            This simplifies execution of subgraphs if you don't care whether inputs to
+            that subgraph are cache invalid. This allows multiple modifications in the
+            Graph before the next run updating the cache.
+            Attention: This may break automatic cache invalidation.
+            And for this to work, any task producing an input
+            for the chosen subgraph may never be used more
+            than once per stage.
         :return: The output from the task as well as the corresponding metadata.
         :raises CacheError: if no matching task exists in the cache
         """

--- a/tests/test_materializing_task.py
+++ b/tests/test_materializing_task.py
@@ -49,10 +49,26 @@ def test_get_output_from_store(imperative):
             result.get(dataframes, as_type=pd.DataFrame)[1],
         )
 
+        pd.testing.assert_frame_equal(
+            df1.get_output_from_store(
+                as_type=pd.DataFrame, ignore_position_hashes=True
+            ),
+            result.get(df1, as_type=pd.DataFrame, ignore_position_hashes=True),
+        )
+
         # Call on MaterializingTaskGetItem
         pd.testing.assert_frame_equal(
             dataframes[0].get_output_from_store(as_type=pd.DataFrame),
             dataframes.get_output_from_store(as_type=pd.DataFrame)[0],
+        )
+
+        pd.testing.assert_frame_equal(
+            dataframes[0].get_output_from_store(
+                as_type=pd.DataFrame, ignore_position_hashes=True
+            ),
+            dataframes.get_output_from_store(
+                as_type=pd.DataFrame, ignore_position_hashes=True
+            )[0],
         )
 
 

--- a/tests/test_materializing_task.py
+++ b/tests/test_materializing_task.py
@@ -49,11 +49,14 @@ def test_get_output_from_store(imperative):
             result.get(dataframes, as_type=pd.DataFrame)[1],
         )
 
+        # since df1 and df2 are outputs from tasks with the same name (pd_dataframe)
+        # ignoring the position hash when retrieving
+        # should just return the output from the latest call
         pd.testing.assert_frame_equal(
             df1.get_output_from_store(
                 as_type=pd.DataFrame, ignore_position_hashes=True
             ),
-            result.get(df1, as_type=pd.DataFrame),
+            result.get(df2, as_type=pd.DataFrame),
         )
 
         # Call on MaterializingTaskGetItem

--- a/tests/test_materializing_task.py
+++ b/tests/test_materializing_task.py
@@ -53,7 +53,7 @@ def test_get_output_from_store(imperative):
             df1.get_output_from_store(
                 as_type=pd.DataFrame, ignore_position_hashes=True
             ),
-            result.get(df1, as_type=pd.DataFrame, ignore_position_hashes=True),
+            result.get(df1, as_type=pd.DataFrame),
         )
 
         # Call on MaterializingTaskGetItem

--- a/tests/test_run_subflow.py
+++ b/tests/test_run_subflow.py
@@ -295,3 +295,18 @@ def test_run_specific_stage_with_table_blob():
     f.run(s2)
     f.run(s3)
     f.run(s1, s3)
+
+
+@with_instances("postgres_ignore_position_hashes")
+def test_ignore_position_hashes():
+    with Flow() as f:
+        with Stage("subflow_s1"):
+            x1 = m.create_tuple(1, 1)
+            x2 = m.create_tuple(x1, x1)
+
+        with Stage("subflow_s2") as s2:
+            _ = m.create_tuple(x1, x2)
+
+    f.run()
+    # check that retrieval from cache works
+    f.run(s2)

--- a/tests/test_run_subflow.py
+++ b/tests/test_run_subflow.py
@@ -308,5 +308,5 @@ def test_ignore_position_hashes():
             _ = m.create_tuple(x1, x2)
 
     f.run()
-    # check that retrieval from cache works
+    # check that subflow evaluation works with ignore_position_hashes
     f.run(s2, ignore_position_hashes=True)

--- a/tests/test_run_subflow.py
+++ b/tests/test_run_subflow.py
@@ -309,4 +309,4 @@ def test_ignore_position_hashes():
 
     f.run()
     # check that retrieval from cache works
-    f.run(s2)
+    f.run(s2, ignore_position_hashes=True)


### PR DESCRIPTION
Added `ignore_position_hashes` option to `SQLTableStore`. 
  If `True`, the position hashes of tasks are not checked when retrieving the inputs of a task from the cache.
  This can prevent caching errors when evaluating subgraphs. 
  For this to work a task may never be used more than once per stage.

# Checklist

- [x] Added a `docs/source/changelog.md` entry
- [ ] Added/updated documentation in `docs/source/`
- [ ] Added/updated examples in `docs/source/examples.md`
