### PR TITLE
bug(): Complex tasks using imperative materialization break caching + release `v 0.9.4`

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -6,6 +6,7 @@
     If `True`, the position hashes of tasks are not checked when retrieving the inputs of a task from the cache.
     This can prevent caching errors when evaluating subgraphs. 
     For this to work a task may never be used more than once per stage.
+- Fixed a bug related to imperative materialization
 
 ## 0.9.3 (2024-06-11)
 - Added `upload_table()` and `download_table()` functions to the PandasTableHook to allow for easy 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.9.4 (XXX)
+## 0.9.4 (2024-07-18)
 - Primary key and index identifiers are now automatically truncated to 63 characters to avoid issues with some database systems.
 - Added `ignore_position_hashes` option to `flow.run()` and `get_output_from_store()`. 
     If `True`, the position hashes of tasks are not checked when retrieving the inputs of a task from the cache.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydiverse-pipedag"
-version = "0.9.3"
+version = "0.9.4"
 description = "A pipeline orchestration library executing tasks within one python session. It takes care of SQL table (de)materialization, caching and cache invalidation. Blob storage is supported as well for example for storing model files."
 authors = [
   "QuantCo, Inc.",

--- a/src/pydiverse/pipedag/backend/table/base.py
+++ b/src/pydiverse/pipedag/backend/table/base.py
@@ -409,6 +409,7 @@ class BaseTableStore(TableHookResolver, Disposable):
                 query_str,
                 cache_metadata=metadata,
             )
+            RunContext.get().trace_hook.cache_init_transfer(task, table)
             self.copy_lazy_table_to_transaction(metadata, table)
             self.logger.info(f"Lazy cache of table '{table.name}' found")
         except CacheError as e:

--- a/src/pydiverse/pipedag/backend/table/base.py
+++ b/src/pydiverse/pipedag/backend/table/base.py
@@ -401,7 +401,14 @@ class BaseTableStore(TableHookResolver, Disposable):
             metadata = self.retrieve_lazy_table_metadata(
                 query_hash, task_cache_info.cache_key, table.stage
             )
-            RunContext.get().trace_hook.query_cache_status(task, table, task_cache_info, query_hash, query_str, cache_metadata=metadata)
+            RunContext.get().trace_hook.query_cache_status(
+                task,
+                table,
+                task_cache_info,
+                query_hash,
+                query_str,
+                cache_metadata=metadata,
+            )
             self.copy_lazy_table_to_transaction(metadata, table)
             self.logger.info(f"Lazy cache of table '{table.name}' found")
         except CacheError as e:
@@ -411,7 +418,9 @@ class BaseTableStore(TableHookResolver, Disposable):
                 "Cache miss", table=table.name, stage=table.stage.name, cause=str(e)
             )
             TaskContext.get().is_cache_valid = False
-            RunContext.get().trace_hook.query_cache_status(task, table, task_cache_info, query_hash, query_str, cache_valid=False)
+            RunContext.get().trace_hook.query_cache_status(
+                task, table, task_cache_info, query_hash, query_str, cache_valid=False
+            )
             if task_cache_info.assert_no_materialization:
                 raise AssertionError(
                     "cache_validation.mode=ASSERT_NO_FRESH_INPUT is a "

--- a/src/pydiverse/pipedag/backend/table/dict.py
+++ b/src/pydiverse/pipedag/backend/table/dict.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from pydiverse.pipedag import Stage, Table
 from pydiverse.pipedag.backend.table.base import BaseTableStore, TableHook
+from pydiverse.pipedag.context import RunContext
 from pydiverse.pipedag.errors import CacheError, StageError
 from pydiverse.pipedag.materialize.core import MaterializingTask
 from pydiverse.pipedag.materialize.metadata import LazyTableMetadata, TaskMetadata
@@ -68,8 +69,10 @@ class DictTableStore(BaseTableStore):
             )
 
         try:
+            RunContext.get().trace_hook.cache_pre_transfer(table)
             t = self.store[stage.name][metadata.name]
             self.store[stage.transaction_name][metadata.name] = t
+            RunContext.get().trace_hook.cache_post_transfer(table)
         except KeyError:
             raise CacheError(
                 f"No table with name '{metadata.name}' found in '{stage.name}' stage"

--- a/src/pydiverse/pipedag/backend/table/sql/sql.py
+++ b/src/pydiverse/pipedag/backend/table/sql/sql.py
@@ -1078,8 +1078,10 @@ class SQLTableStore(BaseTableStore):
         dest_tbl.shared_lock_allowed = True
 
         # Copy table via executing a select statement with respective hook
+        RunContext.get().trace_hook.cache_pre_transfer(dest_tbl)
         hook = self.get_m_table_hook(type(dest_tbl.obj))
         hook.materialize(self, dest_tbl, dest_tbl.stage.transaction_name)
+        RunContext.get().trace_hook.cache_post_transfer(dest_tbl)
 
     def _deferred_copy_table(
         self,

--- a/src/pydiverse/pipedag/context/run_context.py
+++ b/src/pydiverse/pipedag/context/run_context.py
@@ -385,8 +385,9 @@ class RunContextServer(IPCServer):
             fn = getattr(store.table_store, op.fn_name)
             assert callable(fn)
 
+            run_context = self.__context_proxy
             future = self.deferred_thread_pool.submit(
-                _call_with_args, fn, op.args, op.kwargs
+                _call_with_args, fn, run_context, op.args, op.kwargs
             )
             self.deferred_ts_ops_futures[stage_id].append(future)
 
@@ -538,8 +539,9 @@ class RunContextServer(IPCServer):
         return True
 
 
-def _call_with_args(fn, args, kwargs):
-    fn(*args, **kwargs)
+def _call_with_args(fn, run_context, args, kwargs):
+    with run_context:
+        fn(*args, **kwargs)
 
 
 class RunContext(BaseContext):

--- a/src/pydiverse/pipedag/context/run_context.py
+++ b/src/pydiverse/pipedag/context/run_context.py
@@ -238,7 +238,7 @@ class RunContextServer(IPCServer):
             StageState.INITIALIZING,
             StageState.READY,
         )
-        self.trace_hook.stage_init(stage_id, success)
+        self.trace_hook.stage_post_init(stage_id, success)
 
     def enter_commit_stage(self, stage_id: int):
         self.trace_hook.stage_pre_commit(stage_id)

--- a/src/pydiverse/pipedag/context/trace_hook.py
+++ b/src/pydiverse/pipedag/context/trace_hook.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from pydiverse.pipedag import Result, Task, Table
+    from pydiverse.pipedag.context import RunContextServer, RunContext
+    from pydiverse.pipedag._typing import Materializable
+    from pydiverse.pipedag.materialize.cache import TaskCacheInfo
+    from pydiverse.pipedag.materialize.metadata import TaskMetadata
+
+
+class TraceHook:
+    def run_init_context_server(self, run_context_server: RunContextServer):
+        pass
+
+    def run_init_context(self, run_context: RunContext):
+        pass
+
+    def run_complete(self, result: Result):
+        pass
+
+    def stage_init(self, stage_id: int, success: bool):
+        pass
+
+    def stage_pre_commit(self, stage_id: int):
+        pass
+
+    def stage_post_commit(self, stage_id: int, success: bool):
+        pass
+
+    def task_cache_status(self, task: Task, input_hash: str, cache_fn_hash: str, cache_metadata: TaskMetadata | None = None, cached_output: Materializable | None = None, cache_valid: bool | None=None, lazy: bool | None=None):
+        pass
+
+    def task_complete(self):
+        pass
+
+    def query_cache_status(self, task: Task, table: Table, task_cache_info: TaskCacheInfo, query_hash: str, query_str: str, cache_metadata: TaskMetadata | None = None, cache_valid: bool | None=None):
+        pass
+
+    def query_complete(self, task: Task, table: Table):
+        pass
+
+    #def cache_transfer_start(self):
+    #def cache_transfer_complete(self):
+
+
+class PrintTraceHook(TraceHook):
+    def __init__(self):
+        self.logger = structlog.get_logger(logger_name=type(self).__name__)
+        self.run_context = None
+        self.run_context_server = None
+
+    def run_init_context_server(self, run_context_server: RunContextServer):
+        self.run_context_server = run_context_server
+        self.logger.debug("run_init_context_server", run_context_server=run_context_server)
+
+    def run_init_context(self, run_context: RunContext):
+        self.run_context = run_context
+        self.logger.debug("run_init_context", run_context=run_context)
+
+    def run_complete(self, result: Result):
+        self.logger.debug("run_complete", result=result)
+
+    def stage_init(self, stage_id: int, success: bool):
+        self.logger.debug("stage_init", stage_id=stage_id, stage=list(self.run_context.flow.stages.values())[stage_id], success=success)
+
+    def stage_pre_commit(self, stage_id: int):
+        self.logger.debug("stage_pre_commit", stage_id=stage_id, stage=list(self.run_context.flow.stages.values())[stage_id])
+
+    def stage_post_commit(self, stage_id: int, success: bool):
+        self.logger.debug("stage_post_commit", stage_id=stage_id, success=success)
+
+    def task_cache_status(self, task: Task, input_hash: str, cache_fn_hash: str, cache_metadata: TaskMetadata | None = None, cached_output: Materializable | None = None, cache_valid: bool | None=None, lazy: bool | None=None):
+        self.logger.debug("task_cache_status", task=task, input_hash=input_hash, cache_fn_hash=cache_fn_hash, cache_metadata=cache_metadata, cached_output=cached_output, cache_valid=cache_valid, lazy=lazy)
+
+    def task_complete(self):
+        self.logger.debug("task_complete")
+
+    def query_cache_status(self, task: Task, table: Table, task_cache_info: TaskCacheInfo, query_hash: str, query_str: str, cache_metadata: TaskMetadata | None = None, cache_valid: bool | None=None):
+        self.logger.debug("query_cache_status", task=task, table=table, detail=table.assumed_dependencies, task_cache_info=task_cache_info, query_hash=query_hash, query=query_str, cache_metadata=cache_metadata, cache_valid=cache_valid)
+
+    def query_complete(self, task: Task, table: Table):
+        self.logger.debug("query_complete", task=task, table=table)
+
+

--- a/src/pydiverse/pipedag/context/trace_hook.py
+++ b/src/pydiverse/pipedag/context/trace_hook.py
@@ -105,7 +105,7 @@ class TraceHook:
         """
         pass
 
-    def task_complete(self, task: Task):
+    def task_complete(self, task: Task, result: Result):
         """
         Called after task completion.
 
@@ -139,15 +139,25 @@ class TraceHook:
         """
         pass
 
-    def cache_pre_transfer(self):
+    def cache_init_transfer(self, task: Task, table: Table):
         """
-        Called before transferring cache data to transaction schema.
+        Called when preparing transfer from cached table to transactions schema.
         """
         pass
 
-    def cache_post_transfer(self):
+    def cache_pre_transfer(self, table: Table):
         """
-        Called after transferring cache data to transaction schema.
+        Called before transferring cached table to transaction schema.
+
+        This function may be called in context of another thread or process.
+        """
+        pass
+
+    def cache_post_transfer(self, table: Table):
+        """
+        Called after transferring cached table to transaction schema.
+
+        This function may be called in context of another thread or process.
         """
         pass
 
@@ -173,7 +183,7 @@ class PrintTraceHook(TraceHook):
 
     def stage_post_init(self, stage_id: int, success: bool):
         self.logger.debug(
-            "stage_init",
+            "stage_post_init",
             stage_id=stage_id,
             stage=list(self.run_context.flow.stages.values())[stage_id],
             success=success,
@@ -188,6 +198,9 @@ class PrintTraceHook(TraceHook):
 
     def stage_post_commit(self, stage_id: int, success: bool):
         self.logger.debug("stage_post_commit", stage_id=stage_id, success=success)
+
+    def task_begin(self, task: Task):
+        self.logger.debug("task_begin", task=task)
 
     def task_cache_status(
         self,
@@ -214,10 +227,10 @@ class PrintTraceHook(TraceHook):
         self.logger.debug("task_pre_call", task=task)
 
     def task_post_call(self, task: Task):
-        self.logger.debug("task_complete", task=task)
+        self.logger.debug("task_post_call", task=task)
 
-    def task_complete(self, task: Task):
-        self.logger.debug("task_complete", task=task)
+    def task_complete(self, task: Task, result: Result):
+        self.logger.debug("task_complete", task=task, result=result)
 
     def query_cache_status(
         self,
@@ -243,3 +256,12 @@ class PrintTraceHook(TraceHook):
 
     def query_complete(self, task: Task, table: Table):
         self.logger.debug("query_complete", task=task, table=table)
+
+    def cache_init_transfer(self, task: Task, table: Table):
+        self.logger.debug("cache_init_transfer", task=task, table=table)
+
+    def cache_pre_transfer(self, table: Table):
+        self.logger.debug("cache_pre_transfer", table=table)
+
+    def cache_post_transfer(self, table: Table):
+        self.logger.debug("cache_post_transfer", table=table)

--- a/src/pydiverse/pipedag/context/trace_hook.py
+++ b/src/pydiverse/pipedag/context/trace_hook.py
@@ -14,21 +14,59 @@ if TYPE_CHECKING:
 
 class TraceHook:
     def run_init_context_server(self, run_context_server: RunContextServer):
+        """
+        Called after run context server was initialized.
+
+        The run context server launches a central service in case of multi-node
+        execution. Hooks might integrate with it to collect information at a central
+        point.
+        """
         pass
 
     def run_init_context(self, run_context: RunContext):
+        """
+        Called after initialization of run context.
+
+        This happens when entering RunContextServer context.
+        """
         pass
 
     def run_complete(self, result: Result):
+        """
+        Called after completion of pipedag run when result is available.
+        """
         pass
 
-    def stage_init(self, stage_id: int, success: bool):
+    def stage_post_init(self, stage_id: int, success: bool):
+        """
+        Called after initialization of stage.
+
+        The stage schema can be used for writing tables from this moment on.
+        """
         pass
 
     def stage_pre_commit(self, stage_id: int):
+        """
+        Called before committing stage.
+        """
         pass
 
     def stage_post_commit(self, stage_id: int, success: bool):
+        """
+        Called after committing stage.
+
+        Stage commit may include copying remaining tables from cache to transaction
+        schema.
+        """
+        pass
+
+    def task_begin(self, task: Task):
+        """
+        Called at beginning of task execution.
+
+        This typically is just very shortly before task_cache_status. It also can be
+        used as the starting point for dematerialization.
+        """
         pass
 
     def task_cache_status(
@@ -41,9 +79,39 @@ class TraceHook:
         cache_valid: bool | None = None,
         lazy: bool | None = None,
     ):
+        """
+        Called after it is known whether task is cache valid for non-lazy tasks.
+
+        It is not called in case cache validity check is disabled. For lazy tasks,
+        it is also called for technical reasons because the cache_fn_hash may be
+        retrieved from the cache in order to avoid recomputation in some special
+        cases.
+        """
         pass
 
-    def task_complete(self):
+    def task_pre_call(self, task: Task):
+        """
+        Called before call of task function.
+
+        This is the same moment when dematerialization completed.
+        """
+        pass
+
+    def task_post_call(self, task: Task):
+        """
+        Called after call of task function.
+
+        This is the same moment when materialization begins.
+        """
+        pass
+
+    def task_complete(self, task: Task):
+        """
+        Called after task completion.
+
+        This is the same moment when materialization completes.
+        All query related callbacks of this task are called before this.
+        """
         pass
 
     def query_cache_status(
@@ -56,13 +124,32 @@ class TraceHook:
         cache_metadata: TaskMetadata | None = None,
         cache_valid: bool | None = None,
     ):
+        """
+        Called after it is known whether query is cache valid.
+
+        Task caching information is available in task_cache_info.
+        In addition, query_str and table.assumed_dependencies are used for computing
+        query_hash.
+        """
         pass
 
     def query_complete(self, task: Task, table: Table):
+        """
+        Called after query completion in case query is not cache valid.
+        """
         pass
 
-    # def cache_transfer_start(self):
-    # def cache_transfer_complete(self):
+    def cache_pre_transfer(self):
+        """
+        Called before transferring cache data to transaction schema.
+        """
+        pass
+
+    def cache_post_transfer(self):
+        """
+        Called after transferring cache data to transaction schema.
+        """
+        pass
 
 
 class PrintTraceHook(TraceHook):
@@ -84,7 +171,7 @@ class PrintTraceHook(TraceHook):
     def run_complete(self, result: Result):
         self.logger.debug("run_complete", result=result)
 
-    def stage_init(self, stage_id: int, success: bool):
+    def stage_post_init(self, stage_id: int, success: bool):
         self.logger.debug(
             "stage_init",
             stage_id=stage_id,
@@ -123,8 +210,14 @@ class PrintTraceHook(TraceHook):
             lazy=lazy,
         )
 
-    def task_complete(self):
-        self.logger.debug("task_complete")
+    def task_pre_call(self, task: Task):
+        self.logger.debug("task_pre_call", task=task)
+
+    def task_post_call(self, task: Task):
+        self.logger.debug("task_complete", task=task)
+
+    def task_complete(self, task: Task):
+        self.logger.debug("task_complete", task=task)
 
     def query_cache_status(
         self,

--- a/src/pydiverse/pipedag/context/trace_hook.py
+++ b/src/pydiverse/pipedag/context/trace_hook.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import structlog
 
 if TYPE_CHECKING:
-    from pydiverse.pipedag import Result, Task, Table
-    from pydiverse.pipedag.context import RunContextServer, RunContext
+    from pydiverse.pipedag import Result, Table, Task
     from pydiverse.pipedag._typing import Materializable
+    from pydiverse.pipedag.context import RunContext, RunContextServer
     from pydiverse.pipedag.materialize.cache import TaskCacheInfo
     from pydiverse.pipedag.materialize.metadata import TaskMetadata
 
@@ -30,20 +31,38 @@ class TraceHook:
     def stage_post_commit(self, stage_id: int, success: bool):
         pass
 
-    def task_cache_status(self, task: Task, input_hash: str, cache_fn_hash: str, cache_metadata: TaskMetadata | None = None, cached_output: Materializable | None = None, cache_valid: bool | None=None, lazy: bool | None=None):
+    def task_cache_status(
+        self,
+        task: Task,
+        input_hash: str,
+        cache_fn_hash: str,
+        cache_metadata: TaskMetadata | None = None,
+        cached_output: Materializable | None = None,
+        cache_valid: bool | None = None,
+        lazy: bool | None = None,
+    ):
         pass
 
     def task_complete(self):
         pass
 
-    def query_cache_status(self, task: Task, table: Table, task_cache_info: TaskCacheInfo, query_hash: str, query_str: str, cache_metadata: TaskMetadata | None = None, cache_valid: bool | None=None):
+    def query_cache_status(
+        self,
+        task: Task,
+        table: Table,
+        task_cache_info: TaskCacheInfo,
+        query_hash: str,
+        query_str: str,
+        cache_metadata: TaskMetadata | None = None,
+        cache_valid: bool | None = None,
+    ):
         pass
 
     def query_complete(self, task: Task, table: Table):
         pass
 
-    #def cache_transfer_start(self):
-    #def cache_transfer_complete(self):
+    # def cache_transfer_start(self):
+    # def cache_transfer_complete(self):
 
 
 class PrintTraceHook(TraceHook):
@@ -54,7 +73,9 @@ class PrintTraceHook(TraceHook):
 
     def run_init_context_server(self, run_context_server: RunContextServer):
         self.run_context_server = run_context_server
-        self.logger.debug("run_init_context_server", run_context_server=run_context_server)
+        self.logger.debug(
+            "run_init_context_server", run_context_server=run_context_server
+        )
 
     def run_init_context(self, run_context: RunContext):
         self.run_context = run_context
@@ -64,24 +85,68 @@ class PrintTraceHook(TraceHook):
         self.logger.debug("run_complete", result=result)
 
     def stage_init(self, stage_id: int, success: bool):
-        self.logger.debug("stage_init", stage_id=stage_id, stage=list(self.run_context.flow.stages.values())[stage_id], success=success)
+        self.logger.debug(
+            "stage_init",
+            stage_id=stage_id,
+            stage=list(self.run_context.flow.stages.values())[stage_id],
+            success=success,
+        )
 
     def stage_pre_commit(self, stage_id: int):
-        self.logger.debug("stage_pre_commit", stage_id=stage_id, stage=list(self.run_context.flow.stages.values())[stage_id])
+        self.logger.debug(
+            "stage_pre_commit",
+            stage_id=stage_id,
+            stage=list(self.run_context.flow.stages.values())[stage_id],
+        )
 
     def stage_post_commit(self, stage_id: int, success: bool):
         self.logger.debug("stage_post_commit", stage_id=stage_id, success=success)
 
-    def task_cache_status(self, task: Task, input_hash: str, cache_fn_hash: str, cache_metadata: TaskMetadata | None = None, cached_output: Materializable | None = None, cache_valid: bool | None=None, lazy: bool | None=None):
-        self.logger.debug("task_cache_status", task=task, input_hash=input_hash, cache_fn_hash=cache_fn_hash, cache_metadata=cache_metadata, cached_output=cached_output, cache_valid=cache_valid, lazy=lazy)
+    def task_cache_status(
+        self,
+        task: Task,
+        input_hash: str,
+        cache_fn_hash: str,
+        cache_metadata: TaskMetadata | None = None,
+        cached_output: Materializable | None = None,
+        cache_valid: bool | None = None,
+        lazy: bool | None = None,
+    ):
+        self.logger.debug(
+            "task_cache_status",
+            task=task,
+            input_hash=input_hash,
+            cache_fn_hash=cache_fn_hash,
+            cache_metadata=cache_metadata,
+            cached_output=cached_output,
+            cache_valid=cache_valid,
+            lazy=lazy,
+        )
 
     def task_complete(self):
         self.logger.debug("task_complete")
 
-    def query_cache_status(self, task: Task, table: Table, task_cache_info: TaskCacheInfo, query_hash: str, query_str: str, cache_metadata: TaskMetadata | None = None, cache_valid: bool | None=None):
-        self.logger.debug("query_cache_status", task=task, table=table, detail=table.assumed_dependencies, task_cache_info=task_cache_info, query_hash=query_hash, query=query_str, cache_metadata=cache_metadata, cache_valid=cache_valid)
+    def query_cache_status(
+        self,
+        task: Task,
+        table: Table,
+        task_cache_info: TaskCacheInfo,
+        query_hash: str,
+        query_str: str,
+        cache_metadata: TaskMetadata | None = None,
+        cache_valid: bool | None = None,
+    ):
+        self.logger.debug(
+            "query_cache_status",
+            task=task,
+            table=table,
+            detail=table.assumed_dependencies,
+            task_cache_info=task_cache_info,
+            query_hash=query_hash,
+            query=query_str,
+            cache_metadata=cache_metadata,
+            cache_valid=cache_valid,
+        )
 
     def query_complete(self, task: Task, table: Table):
         self.logger.debug("query_complete", task=task, table=table)
-
-

--- a/src/pydiverse/pipedag/core/flow.py
+++ b/src/pydiverse/pipedag/core/flow.py
@@ -17,9 +17,9 @@ from pydiverse.pipedag.context import (
     RunContextServer,
 )
 from pydiverse.pipedag.context.context import CacheValidationMode
+from pydiverse.pipedag.context.trace_hook import TraceHook
 from pydiverse.pipedag.core.config import PipedagConfig
 from pydiverse.pipedag.core.group_node import BarrierTask, VisualizationStyle
-from pydiverse.pipedag.context.trace_hook import TraceHook
 from pydiverse.pipedag.errors import DuplicateNameError, FlowError
 
 if TYPE_CHECKING:

--- a/src/pydiverse/pipedag/core/stage.py
+++ b/src/pydiverse/pipedag/core/stage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+from functools import total_ordering
 from typing import TYPE_CHECKING
 
 import structlog
@@ -14,6 +15,7 @@ if TYPE_CHECKING:
     from pydiverse.pipedag import Flow, GroupNode
 
 
+@total_ordering
 class Stage:
     """A stage represents a collection of related tasks.
 

--- a/src/pydiverse/pipedag/materialize/core.py
+++ b/src/pydiverse/pipedag/materialize/core.py
@@ -665,7 +665,9 @@ class MaterializationWrapper:
                         cache_fn_hash=cache_fn_hash,
                     )
                     TaskContext.get().is_cache_valid = True
-                    RunContext.get().trace_hook.task_cache_status(task, input_hash, cache_fn_hash, cache_metadata, cached_output)
+                    RunContext.get().trace_hook.task_cache_status(
+                        task, input_hash, cache_fn_hash, cache_metadata, cached_output
+                    )
                     return cached_output
                 except CacheError as e:
                     task.logger.info(
@@ -676,7 +678,9 @@ class MaterializationWrapper:
                         cause=str(e),
                     )
                     TaskContext.get().is_cache_valid = False
-                    RunContext.get().trace_hook.task_cache_status(task, input_hash, cache_fn_hash, cache_valid=False)
+                    RunContext.get().trace_hook.task_cache_status(
+                        task, input_hash, cache_fn_hash, cache_valid=False
+                    )
 
             if not task.lazy:
                 if assert_no_fresh_input and task.cache is not None:
@@ -706,7 +710,9 @@ class MaterializationWrapper:
                             task, input_hash, ""
                         )
                         cache_fn_hash = cache_metadata.cache_fn_hash
-                        RunContext.get().trace_hook.task_cache_status(task, input_hash, cache_fn_hash, cache_metadata, lazy=True)
+                        RunContext.get().trace_hook.task_cache_status(
+                            task, input_hash, cache_fn_hash, cache_metadata, lazy=True
+                        )
                     except CacheError as e:
                         task.logger.info(
                             "Failed to retrieve lazy task from cache",

--- a/src/pydiverse/pipedag/materialize/core.py
+++ b/src/pydiverse/pipedag/materialize/core.py
@@ -766,7 +766,7 @@ class MaterializationWrapper:
                         "The table has already been imperatively materialized."
                     )
                 table.assumed_dependencies = (
-                    list(state.assumed_dependencies)
+                    list(sorted(state.assumed_dependencies))
                     if len(state.assumed_dependencies) > 0
                     else []
                 )
@@ -819,7 +819,9 @@ class MaterializationWrapper:
                     # materialized
                     if len(state.assumed_dependencies) > 0:
                         if x.assumed_dependencies is None:
-                            x.assumed_dependencies = list(state.assumed_dependencies)
+                            x.assumed_dependencies = list(
+                                sorted(state.assumed_dependencies)
+                            )
                 return x
 
             result = deep_map(result, result_finalization_mutator)

--- a/src/pydiverse/pipedag/materialize/core.py
+++ b/src/pydiverse/pipedag/materialize/core.py
@@ -665,6 +665,7 @@ class MaterializationWrapper:
                         cache_fn_hash=cache_fn_hash,
                     )
                     TaskContext.get().is_cache_valid = True
+                    RunContext.get().trace_hook.task_cache_status(task, input_hash, cache_fn_hash, cache_metadata, cached_output)
                     return cached_output
                 except CacheError as e:
                     task.logger.info(
@@ -675,6 +676,7 @@ class MaterializationWrapper:
                         cause=str(e),
                     )
                     TaskContext.get().is_cache_valid = False
+                    RunContext.get().trace_hook.task_cache_status(task, input_hash, cache_fn_hash, cache_valid=False)
 
             if not task.lazy:
                 if assert_no_fresh_input and task.cache is not None:
@@ -704,6 +706,7 @@ class MaterializationWrapper:
                             task, input_hash, ""
                         )
                         cache_fn_hash = cache_metadata.cache_fn_hash
+                        RunContext.get().trace_hook.task_cache_status(task, input_hash, cache_fn_hash, cache_metadata, lazy=True)
                     except CacheError as e:
                         task.logger.info(
                             "Failed to retrieve lazy task from cache",

--- a/src/pydiverse/pipedag/util/structlog.py
+++ b/src/pydiverse/pipedag/util/structlog.py
@@ -86,7 +86,7 @@ def setup_logging(
             structlog.dev.set_exc_info,
             structlog.processors.add_log_level,
             structlog.processors.TimeStamper(timestamp_format),
-            PipedagConsoleRenderer(render_keys=["query", "table_obj"]),
+            PipedagConsoleRenderer(render_keys=["query", "table_obj", "task", "table", "detail"]),
         ],
         wrapper_class=structlog.make_filtering_bound_logger(log_level),
         logger_factory=structlog.PrintLoggerFactory(log_stream),

--- a/src/pydiverse/pipedag/util/structlog.py
+++ b/src/pydiverse/pipedag/util/structlog.py
@@ -86,7 +86,9 @@ def setup_logging(
             structlog.dev.set_exc_info,
             structlog.processors.add_log_level,
             structlog.processors.TimeStamper(timestamp_format),
-            PipedagConsoleRenderer(render_keys=["query", "table_obj", "task", "table", "detail"]),
+            PipedagConsoleRenderer(
+                render_keys=["query", "table_obj", "task", "table", "detail"]
+            ),
         ],
         wrapper_class=structlog.make_filtering_bound_logger(log_level),
         logger_factory=structlog.PrintLoggerFactory(log_stream),

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -160,7 +160,10 @@ def test_imperative_minimal_example():
             _ = m.complex_imperative_materialize(in_)
 
     trace_hook = PrintTraceHook()
-    result1 = f.run(cache_validation_mode=CacheValidationMode.FORCE_CACHE_INVALID, trace_hook=trace_hook)
+    result1 = f.run(
+        cache_validation_mode=CacheValidationMode.FORCE_CACHE_INVALID,
+        trace_hook=trace_hook,
+    )
 
     result2 = f.run(trace_hook=trace_hook)
 

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -159,7 +159,7 @@ def test_imperative_minimal_example():
         with Stage("stage"):
             _ = m.complex_imperative_materialize(in_)
 
-    trace_hook = PrintTraceHook()
+    trace_hook = PrintTraceHook()  # can be used to debug caching issues
     result1 = f.run(
         cache_validation_mode=CacheValidationMode.FORCE_CACHE_INVALID,
         trace_hook=trace_hook,

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -8,6 +8,7 @@ import structlog
 from pydiverse.pipedag import ConfigContext, Flow, Stage, Table, materialize
 from pydiverse.pipedag.context import FinalTaskState, RunContext, StageLockContext
 from pydiverse.pipedag.context.context import CacheValidationMode
+from pydiverse.pipedag.context.trace_hook import PrintTraceHook
 from pydiverse.pipedag.core.config import PipedagConfig
 
 # Parameterize all tests in this file with several instance_id configurations
@@ -158,9 +159,10 @@ def test_imperative_minimal_example():
         with Stage("stage"):
             _ = m.complex_imperative_materialize(in_)
 
-    result1 = f.run(cache_validation_mode=CacheValidationMode.FORCE_CACHE_INVALID)
+    trace_hook = PrintTraceHook()
+    result1 = f.run(cache_validation_mode=CacheValidationMode.FORCE_CACHE_INVALID, trace_hook=trace_hook)
 
-    result2 = f.run()
+    result2 = f.run(trace_hook=trace_hook)
 
     print("Run 1:")
     for task in f.tasks:

--- a/tests/test_materialize.py
+++ b/tests/test_materialize.py
@@ -154,9 +154,9 @@ def test_debug_materialize_table_twice(imperative):
 def test_imperative_minimal_example():
     with Flow("flow") as f:
         with Stage("input"):
-            input = m.simple_dataframe()
+            in_ = m.simple_dataframe()
         with Stage("stage"):
-            _ = m.complex_imperative_materialize(input)
+            _ = m.complex_imperative_materialize(in_)
 
     result1 = f.run(cache_validation_mode=CacheValidationMode.FORCE_CACHE_INVALID)
 

--- a/tests/util/tasks_library.py
+++ b/tests/util/tasks_library.py
@@ -217,12 +217,12 @@ def simple_dataframe_debug_materialize_twice():
 
 
 def complex_imperative_materialize(in_: Table):
-    @materialize(lazy=True, in__type=sa.Table)
+    @materialize(lazy=True, input_type=sa.Table)
     def _temp_res1(in_: sa.Table):
         query = sa.select("*").select_from(in_)
         return Table(query)
 
-    @materialize(lazy=True, in__type=sa.Table)
+    @materialize(lazy=True, input_type=sa.Table)
     def _temp_res2(in_: sa.Table):
         query1 = sa.select("*").select_from(in_)
         t1 = Table(query1).materialize()
@@ -233,7 +233,7 @@ def complex_imperative_materialize(in_: Table):
         query3 = sa.select("*").select_from(t2)
         return Table(query3)
 
-    @materialize(lazy=True, in__type=sa.Table)
+    @materialize(lazy=True, input_type=sa.Table)
     def _temp_res3(_temp_res1: sa.Table, _temp_res2: sa.Table):
         _ = _temp_res2
         query = sa.select("*").select_from(_temp_res1)

--- a/tests/util/tasks_library.py
+++ b/tests/util/tasks_library.py
@@ -216,15 +216,15 @@ def simple_dataframe_debug_materialize_twice():
     return res
 
 
-def complex_imperative_materialize(input: Table):
-    @materialize(lazy=True, input_type=sa.Table)
-    def _temp_res1(input: sa.Table):
-        query = sa.select("*").select_from(input)
+def complex_imperative_materialize(in_: Table):
+    @materialize(lazy=True, in__type=sa.Table)
+    def _temp_res1(in_: sa.Table):
+        query = sa.select("*").select_from(in_)
         return Table(query)
 
-    @materialize(lazy=True, input_type=sa.Table)
-    def _temp_res2(input: sa.Table):
-        query1 = sa.select("*").select_from(input)
+    @materialize(lazy=True, in__type=sa.Table)
+    def _temp_res2(in_: sa.Table):
+        query1 = sa.select("*").select_from(in_)
         t1 = Table(query1).materialize()
 
         query2 = sa.select("*").select_from(t1)
@@ -233,13 +233,13 @@ def complex_imperative_materialize(input: Table):
         query3 = sa.select("*").select_from(t2)
         return Table(query3)
 
-    @materialize(lazy=True, input_type=sa.Table)
+    @materialize(lazy=True, in__type=sa.Table)
     def _temp_res3(_temp_res1: sa.Table, _temp_res2: sa.Table):
         _ = _temp_res2
         query = sa.select("*").select_from(_temp_res1)
         return Table(query)
 
-    temp_res1 = _temp_res1(input)
+    temp_res1 = _temp_res1(in_)
     temp_res2 = _temp_res2(temp_res1)
     return _temp_res3(temp_res1, temp_res2)
 

--- a/tests/util/tasks_library.py
+++ b/tests/util/tasks_library.py
@@ -216,6 +216,34 @@ def simple_dataframe_debug_materialize_twice():
     return res
 
 
+def complex_imperative_materialize(input: Table):
+    @materialize(lazy=True, input_type=sa.Table)
+    def _temp_res1(input: sa.Table):
+        query = sa.select("*").select_from(input)
+        return Table(query)
+
+    @materialize(lazy=True, input_type=sa.Table)
+    def _temp_res2(input: sa.Table):
+        query1 = sa.select("*").select_from(input)
+        t1 = Table(query1).materialize()
+
+        query2 = sa.select("*").select_from(t1)
+        t2 = Table(query2).materialize()
+
+        query3 = sa.select("*").select_from(t2)
+        return Table(query3)
+
+    @materialize(lazy=True, input_type=sa.Table)
+    def _temp_res3(_temp_res1: sa.Table, _temp_res2: sa.Table):
+        _ = _temp_res2
+        query = sa.select("*").select_from(_temp_res1)
+        return Table(query)
+
+    temp_res1 = _temp_res1(input)
+    temp_res2 = _temp_res2(temp_res1)
+    return _temp_res3(temp_res1, temp_res2)
+
+
 @materialize(version="1.0")
 def simple_dataframe_with_pk():
     df = pd.DataFrame(


### PR DESCRIPTION
@windiana42 My expectation is that even when using imperative materialization in a task it should stay cache valid if its inputs did not change. In complex cases this can break.

This PR serves as a minimal example:` test_materialize.py::test_imperative_minimal_example`