### PR TITLE
Disable twine check in publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,3 +62,7 @@ jobs:
           path: dist
       - name: Publish package on PyPi
         uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0
+        with:
+          # the twine version in the container is outdated
+          # and results in a false positive
+          verify-metadata: false


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

# Checklist

- [ ] Added a `docs/source/changelog.md` entry
- [ ] Added/updated documentation in `docs/source/`
- [ ] Added/updated examples in `docs/source/examples.md`

We run `twine check` anyway before.

```
❯ pixi exec -s twine=5.1.1 -- twine check dist/*
Checking dist/pydiverse_pipedag-0.9.8-py3-none-any.whl: ERROR    InvalidDistribution: Metadata is missing required fields: Name, Version.                                   
         Make sure the distribution includes the files where those fields are specified, and is using a supported   
         Metadata-Version: 1.0, 1.1, 1.2, 2.0, 2.1, 2.2, 2.3.                                                       
❯ pixi exec -s twine=6.1.0 -- twine check dist/*
Checking dist/pydiverse_pipedag-0.9.8-py3-none-any.whl: PASSED
Checking dist/pydiverse_pipedag-0.9.9-py3-none-any.whl: PASSED
Checking dist/pydiverse_pipedag-0.9.8.tar.gz: PASSED
Checking dist/pydiverse_pipedag-0.9.9.tar.gz: PASSED
```
