### PR TITLE
ci: Increase timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ on:
         default: 4
         type: number
       timeout-minutes:
-        default: 10
+        default: 30
         type: number
     secrets:
       SNOWFLAKE_PASSWORD:


### PR DESCRIPTION
Currently many CI runs are crashing, because setting up the environment takes almost all of the available time. This PR increases the timeout from 10 minutes to 30.