### PR TITLE
ci: Use SQL Server docker image instead of Azure edge

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     ports:
       - "6543:5432"
   mssql:
-    image: mcr.microsoft.com/azure-sql-edge
+    image: "mcr.microsoft.com/mssql/server:2022-latest"
     environment:
       ACCEPT_EULA: Y
       SA_PASSWORD: PydiQuant27

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.9.11 (2025-XX-XX)
 - Fix numpy import issue on OS X
+- CI: Use SQL Server docker image instead of Azure Edge
 
 ## 0.9.10 (2025-03-18)
 - Fix incompatibility with pydiverse.transform >=0.2.1 (<0.2.0 still supported) (0.2.0 will not be supported):


### PR DESCRIPTION
I suggest using the SQL Server docker image instead of Azure edge:
1. We intend to support SQL Server and only used Azure edge as a proxy for its functionality.
2. Azure edge will be discontinued in October 2025: https://azure.microsoft.com/de-de/updates?id=azure-sql-edge-retirement

# Checklist

- [x] Added a `docs/source/changelog.md` entry
