### PR TITLE
fix: Correct warning message for polars upload_table

### DIFF
--- a/src/pydiverse/pipedag/backend/table/sql/dialects/mssql.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/mssql.py
@@ -635,7 +635,7 @@ class PolarsTableHook(DataframeMsSQLTableHook, PolarsTableHook):
             try:
                 return cls.upload_table_bulk_insert(table, schema, dtypes, store, early)
             except:  # noqa
-                store.logger.warning("Failed to upload table using bulk insert, falling back to arrow odbc.")
+                store.logger.warning("Failed to upload table using bulk insert, falling back to polars.write_database.")
         super().upload_table(table, schema, dtypes, store, early)
 
 


### PR DESCRIPTION
`polars.write_database` uses either `pandas.to_sql` or `adbc` but not `arrow-odbc`.
