### PR TITLE
feat: Add `write_local_table_cache` to `Result.get()`

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.10.8 (2025-XX-XX)
 - Fix: Only cut MSSQL VARCHAR(N) in arrow-odbc download if N is MAX
+- Feat: Add support for parameter `write_local_table_cache` in `Result.get()`
 
 ## 0.10.7 (2025-08-01)
 - IBM DB2: massive speedup by using ADMIN_CMD('LOAD FROM (SELECT...') instead of INSERT INTO SELECT

--- a/src/pydiverse/pipedag/context/run_context.py
+++ b/src/pydiverse/pipedag/context/run_context.py
@@ -734,6 +734,7 @@ class DematerializeRunContext(BaseAttrsContext):
     _context_var = RunContext._context_var
 
     flow: "Flow"
+    allow_write_local_table_cache: bool
 
     def get_stage_state(self, stage: "Stage") -> StageState:
         _ = stage
@@ -744,7 +745,7 @@ class DematerializeRunContext(BaseAttrsContext):
 
     def should_store_table_in_cache(self, table: "Table"):
         _ = table
-        return False
+        return self.allow_write_local_table_cache
 
 
 # Stage Locking

--- a/src/pydiverse/pipedag/core/result.py
+++ b/src/pydiverse/pipedag/core/result.py
@@ -94,6 +94,9 @@ class Result:
             stored in the local table cache, if it is not already there and cache valid.
             If no local table cache is configured or the type as which the table is retrieved,
             is not compatible with the local table cache, this flag has no effect.
+
+            .. Warning:: It is not safe to call this method with `write_local_table_cache=True` from several threads at the same time.
+
         :return: The results of the task.
         """
         from pydiverse.pipedag.materialize.store import dematerialize_output_from_store

--- a/src/pydiverse/pipedag/core/result.py
+++ b/src/pydiverse/pipedag/core/result.py
@@ -16,7 +16,8 @@ from pydiverse.pipedag.core.task import Task, TaskGetItem
 from pydiverse.pipedag.errors import LockError
 
 if TYPE_CHECKING:
-    pass
+    from pydiverse.pipedag.core import Flow, Subflow
+    from pydiverse.pipedag.core.flow import pydot
 
 
 @frozen
@@ -95,7 +96,8 @@ class Result:
             If no local table cache is configured or the type as which the table is retrieved,
             is not compatible with the local table cache, this flag has no effect.
 
-            .. Warning:: It is not safe to call this method with `write_local_table_cache=True` from several threads at the same time.
+            .. Warning:: It is not safe to call this method with `write_local_table_cache=True`
+                from several threads at the same time.
 
         :return: The results of the task.
         """

--- a/src/pydiverse/pipedag/core/result.py
+++ b/src/pydiverse/pipedag/core/result.py
@@ -91,7 +91,7 @@ class Result:
         :param as_type: The type as which tables produced by this task should
             be dematerialized. If no type is specified, the input type of
             the task is used.
-        :param write_local_table_cache: Flag that determines, whether the result should be
+        :param write_local_table_cache: Flag that determines whether the table should be
             stored in the local table cache, if it is not already there and cache valid.
             If no local table cache is configured or the type as which the table is retrieved,
             is not compatible with the local table cache, this flag has no effect.

--- a/src/pydiverse/pipedag/materialize/core.py
+++ b/src/pydiverse/pipedag/materialize/core.py
@@ -725,7 +725,7 @@ def _get_output_from_store(
     root_task = task if isinstance(task, Task) else task.task
 
     store = ConfigContext.get().store
-    with DematerializeRunContext(root_task.flow):
+    with DematerializeRunContext(root_task.flow, allow_write_local_table_cache=False):
         cached_output, _ = store.retrieve_most_recent_task_output_from_cache(
             root_task, ignore_position_hashes=ignore_position_hashes
         )

--- a/tests/test_cache/test_local_table_cache.py
+++ b/tests/test_cache/test_local_table_cache.py
@@ -3,9 +3,10 @@
 
 import pandas as pd
 import polars as pl
+import pytest
 import sqlalchemy as sa
 
-from pydiverse.pipedag import ConfigContext, Flow, Stage, Table, materialize
+from pydiverse.pipedag import ConfigContext, Flow, Stage, StageLockContext, Table, materialize
 from tests.fixtures.instances import with_instances
 
 
@@ -15,7 +16,10 @@ from tests.fixtures.instances import with_instances
     "local_table_cache_inout_numpy",
     "local_table_store",
 )
-def test_local_table_cache(mocker):
+@pytest.mark.parametrize(
+    "write_local_table_cache", [True, False], ids=["write_local_table_cache", "no_write_local_table_cache"]
+)
+def test_local_table_cache(mocker, write_local_table_cache):
     input_val_ = 0
 
     @materialize()
@@ -37,6 +41,11 @@ def test_local_table_cache(mocker):
         # Not supported by local caching
         return Table(sa.select(sa.literal(x).label("x")), "sql")
 
+    @materialize(lazy=True)
+    def select_sql_2(x):
+        # Not supported by local caching
+        return Table(sa.select(sa.literal(x).label("x")), "sql_2")
+
     @materialize(version="1.0", input_type=pd.DataFrame)
     def sink_pandas(*args):
         for arg in args:
@@ -54,12 +63,13 @@ def test_local_table_cache(mocker):
             _ = arg.c.x
 
     with Flow() as f:
-        with Stage("stage"):
+        with Stage("stage") as s:
             x = input_val()
 
             s_pandas = select_pandas(x)
             s_polars = select_polars(x)
             s_sql = select_sql(x)
+            s_sql_2 = select_sql_2(x)
 
             _ = sink_pandas(s_pandas, s_polars, s_sql)
             _ = sink_polars(s_pandas, s_polars, s_sql)
@@ -67,16 +77,27 @@ def test_local_table_cache(mocker):
 
     # Initial run to invalidate cache
     input_val_ = -1
-    f.run()
+    with StageLockContext():
+        res = f.run()
+        df_pl_s_sql_2 = res.get(s_sql_2, as_type=pl.DataFrame, write_local_table_cache=write_local_table_cache)
+        df_pd_s_sql_2 = res.get(s_sql_2, as_type=pd.DataFrame, write_local_table_cache=write_local_table_cache)
+        _ = res.get(s_sql_2, as_type=sa.Table, write_local_table_cache=write_local_table_cache)
+    assert df_pl_s_sql_2.item() == input_val_
+    assert df_pd_s_sql_2.iloc[0]["x"] == input_val_
     input_val_ = 0
 
-    # Spy Setup
     config_context = ConfigContext.get()
     local_table_cache = config_context.store.local_table_cache
+    # We need to clear the cache to ensure that it does not contain results from the previous run
+    # when write_local_table_cache was True.
+    # These outputs are not automatically overwritten, if we have not set write_local_table_cache to False.
+    local_table_cache.clear_cache(s)
+    # Spy Setup
 
     si = int(local_table_cache.should_store_input)
     so = int(local_table_cache.should_store_output)
     siac = int(local_table_cache.should_use_stored_input_as_cache)
+    wltc = int(write_local_table_cache)
 
     store_table_spy = mocker.spy(local_table_cache, "store_table")
     store_input_spy = mocker.spy(local_table_cache, "store_input")
@@ -86,19 +107,33 @@ def test_local_table_cache(mocker):
     _retrieve_table_obj_spy = mocker.spy(local_table_cache, "_retrieve_table_obj")
 
     # Initial Run
-    f.run()
+    with StageLockContext():
+        res = f.run()
+        df_pl_s_sql_2 = res.get(s_sql_2, as_type=pl.DataFrame, write_local_table_cache=write_local_table_cache)
+        df_pd_s_sql_2 = res.get(s_sql_2, as_type=pd.DataFrame, write_local_table_cache=write_local_table_cache)
+        _ = res.get(s_sql_2, as_type=sa.Table, write_local_table_cache=write_local_table_cache)
+    assert df_pl_s_sql_2.item() == input_val_
+    assert df_pd_s_sql_2.iloc[0]["x"] == input_val_
 
-    expected_retrieve_table_obj = 3 * 3
-    expected_successful_retrieve_table_obj = 2 * so * siac + 3 * siac
-    expected_store_table = 3
-    expected_store_input = expected_store_table * 3 - expected_successful_retrieve_table_obj
+    expected_retrieve_table_obj = 3 * 3 + 3
+    expected_successful_retrieve_table_obj = 2 * so * siac + 3 * siac + 1 * wltc * siac
+    expected_store_table_no_sql_2 = 3
+    expected_store_table_sql_2 = 1
+    table_exists_but_store_incompatible = 3 + 1 * wltc  # 3 from sink_sql, 1 from retrieving s_sql_2 as sa.Table
+    expected_store_table = expected_store_table_no_sql_2 + expected_store_table_sql_2
+    expected_store_input = (
+        expected_store_table_no_sql_2 * 3 + expected_store_table_sql_2 * 3 - expected_successful_retrieve_table_obj
+    )
 
     assert store_table_spy.call_count == expected_store_table
     assert store_input_spy.call_count == expected_store_input
     assert retrieve_table_obj_spy.call_count == expected_retrieve_table_obj
 
     assert _store_table_spy.call_count == (expected_store_input * si) + (expected_store_table * so)
-    assert _retrieve_table_obj_spy.call_count == expected_successful_retrieve_table_obj + siac * expected_store_table
+    assert (
+        _retrieve_table_obj_spy.call_count
+        == expected_successful_retrieve_table_obj + siac * table_exists_but_store_incompatible
+    )
 
     # Second Run
     store_table_spy.reset_mock()
@@ -107,9 +142,19 @@ def test_local_table_cache(mocker):
     retrieve_table_obj_spy.reset_mock()
     _retrieve_table_obj_spy.reset_mock()
 
-    f.run()
+    with StageLockContext():
+        res = f.run()
+        df_pl_s_sql_2 = res.get(s_sql_2, as_type=pl.DataFrame, write_local_table_cache=write_local_table_cache)
+        df_pd_s_sql_2 = res.get(s_sql_2, as_type=pd.DataFrame, write_local_table_cache=write_local_table_cache)
+        _ = res.get(s_sql_2, as_type=sa.Table, write_local_table_cache=write_local_table_cache)
+    assert df_pl_s_sql_2.item() == input_val_
+    assert df_pd_s_sql_2.iloc[0]["x"] == input_val_
 
     # Everything should be cache valid, thus no task should get executed.
+    # However, we still load the table from the cache.
+    expected_retrieve_table_obj = 3
+    expected_successful_retrieve_table_obj = 2 * wltc * siac
+    expected_store_input = expected_retrieve_table_obj - expected_successful_retrieve_table_obj
     assert store_table_spy.call_count == 0
-    assert store_input_spy.call_count == 0
-    assert retrieve_table_obj_spy.call_count == 0
+    assert store_input_spy.call_count == expected_store_input
+    assert retrieve_table_obj_spy.call_count == expected_retrieve_table_obj


### PR DESCRIPTION
Make it possible to enable writing to the local table cache after the flow has finished when calling `Result.get()`.

# Checklist

- [x] Added a `docs/source/changelog.md` entry
- [x] Added/updated documentation in `docs/source/`
- [ ] Added/updated examples in `docs/source/examples.md`
