### PR TITLE
Defer initialization of instance_id and fix problem in ParquetTableCache with multi-config code.

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.11 (2025-09-08)
+- Fix: Late initialization of ParquetTableCache instance_id allows use of multi-config `@input_stage_versions`
+
 ## 0.10.10 (2025-09-05)
 - support separate metadata_table_store to allow team-synchronization for example for duckdb based ParquetTableStore
 - Fix: improve handling of missing ADBC/ConnectorX installations and error messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydiverse-pipedag"
-version = "0.10.10"
+version = "0.10.11"
 description = "A pipeline orchestration library executing tasks within one python session. It takes care of SQL table (de)materialization, caching and cache invalidation. Blob storage is supported as well for example for storing model files."
 authors = [
   { name = "QuantCo, Inc." },

--- a/src/pydiverse/pipedag/backend/table/sql/dialects/duckdb_parquet.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/duckdb_parquet.py
@@ -27,7 +27,6 @@ from pydiverse.pipedag.materialize.table_hook_base import (
     CanRetResult,
     TableHook,
 )
-from pydiverse.pipedag.util import normalize_name
 from pydiverse.pipedag.util.path import is_file_uri
 
 try:
@@ -203,8 +202,7 @@ class ParquetTableStore(DuckDBTableStore):
     @classmethod
     def _init_conf_(cls, config: dict[str, Any]):
         config = config.copy()
-        instance_id = normalize_name(ConfigContext.get().instance_id)
-        config["parquet_base_path"] = UPath(config["parquet_base_path"]) / instance_id
+        config["parquet_base_path"] = UPath(config["parquet_base_path"])
         return super()._init_conf_(config)
 
     def __init__(
@@ -763,7 +761,7 @@ class ParquetTableStore(DuckDBTableStore):
         self.parquet_deferred_copy.clear()
 
     def get_parquet_path(self, schema: Schema):
-        return self.parquet_base_path / schema.get()
+        return self.parquet_base_path / self.instance_id / schema.get()
 
     def get_parquet_schema_path(self, schema: Schema) -> UPath:
         # Parquet files are stored in transaction schema while stage.current_name

--- a/src/pydiverse/pipedag/context/context.py
+++ b/src/pydiverse/pipedag/context/context.py
@@ -308,6 +308,7 @@ class ConfigContext(BaseAttrsContext):
             # replace the default derived class for a specific dialect, set
             # `_dialect_name = DISABLE_DIALECT_REGISTRATION`.
             table_store = load_object(table_store_config)
+            table_store.set_instance_id(self.instance_id)
             metadata_table_store_config = self._config_dict["table_store"].get("metadata_table_store", None)
             if metadata_table_store_config:
                 if not hasattr(table_store, "set_metadata_store"):

--- a/src/pydiverse/pipedag/materialize/store.py
+++ b/src/pydiverse/pipedag/materialize/store.py
@@ -64,6 +64,11 @@ class BaseTableStore(TableHookResolver, Disposable):
     def __init__(self):
         self.logger = structlog.get_logger(logger_name=type(self).__name__)
         self.local_table_cache: BaseTableCache | None = None
+        # this field is initialized directly after construction in ConfigContext.store property
+        self.instance_id = "<not-yet-initialized>"
+
+    def set_instance_id(self, instance_id: str):
+        self.instance_id = instance_id
 
     def setup(self):
         """Setup function


### PR DESCRIPTION
This is necessary for handling multiple configurations (e.g. @input_stage_versions)

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

# Checklist

- [x] Added a `docs/source/changelog.md` entry
- [x] Added/updated documentation in `docs/source/`
- [x] Added/updated examples in `docs/source/examples.md`
