### PR TITLE
fix: Convert `pyarrow_path` to string in `PandasTableHook`

### DIFF
--- a/src/pydiverse/pipedag/backend/table/sql/dialects/duckdb_parquet.py
+++ b/src/pydiverse/pipedag/backend/table/sql/dialects/duckdb_parquet.py
@@ -1153,7 +1153,7 @@ class PandasTableHook(sql_hooks.PandasTableHook):
 
             pyarrow_fs = pyarrow.fs.S3FileSystem(endpoint_override=store.s3_endpoint_url, region=store.s3_region)
         else:
-            pyarrow_path = path
+            pyarrow_path = str(path)
             pyarrow_fs = None
         return pyarrow_path, pyarrow_fs
 


### PR DESCRIPTION
This PR converts `pyarrow_path` to string in `PandasTableHook` when the returned pyarrow_fs is None. This provides better compatibility for Google Cloud. As the returned `pyarrow_fs` is `None`, I expect the conversion to string not to affect other protocols (such as `s3`).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

# Checklist

- [ ] Added a `docs/source/changelog.md` entry
